### PR TITLE
Fix mockito mocks exclusion from analysis

### DIFF
--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -8,6 +8,7 @@ analyzer:
     - 'lib/generated_plugin_registrant.dart'
 
     # mockito
+    - '*.mocks.dart'
     - '**/*.mocks.dart'
 
     # freezed


### PR DESCRIPTION
Using `**/*.ext.to.ignore` allows us to ignore files inside nested directories, but doesn't work when we have the ignored files on the same level as the `analysis_options.yaml` file. 
This problem occurs in tests.