### PR TITLE
add cast_nullable_to_non_nullable lint

### DIFF
--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -120,6 +120,8 @@ linter:
     - camel_case_extensions
     - camel_case_types
     - cancel_subscriptions
+    # Similar to avoid-non-null-assertion, which is already used,
+    # basically it suggests to not ignore possible null value
     - cast_nullable_to_non_nullable
     - close_sinks
     - comment_references

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -120,6 +120,7 @@ linter:
     - camel_case_extensions
     - camel_case_types
     - cancel_subscriptions
+    - cast_nullable_to_non_nullable
     - close_sinks
     - comment_references
     # available in later releases


### PR DESCRIPTION
**Rationale:** this lint is similar to `avoid-non-null-assertion` which is already used, basically it suggests to not ignore possible `null` value