### PR TITLE
Update DCM to 5.7.3, use new member-ordering rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.0.16
+
+- Update `dart_code_metrics` dependency to 5.7.3
+- Rename deprecated `member-ordering-extended` to `member-ordering`
+- Add rule for widgets methods order configuration:
+    - initState
+    - build
+    - didChangeDependencies
+    - didUpdateWidget
+    - deactivate
+    - dispose
+
 ## 0.0.15
 
 - Add support for Dart 3

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -61,12 +61,19 @@ dart_code_metrics:
     - avoid-unrelated-type-assertions
     - avoid-unused-parameters
     - double-literal-format
-    - member-ordering-extended:
+    - member-ordering:
         order:
           - fields
           - getters-setters
           - constructors
           - methods
+        widgets-order:
+          - init-state-method
+          - build-method
+          - did-change-dependencies-method
+          - did-update-widget-method
+          - deactivate-method
+          - dispose-method
     - newline-before-return
     - no-empty-block
     - no-equal-then-else

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,11 +2,11 @@ name: solid_lints
 description:
   Lints for Dart and Flutter based on software industry standards and best
   practices.
-version: 0.0.15
+version: 0.0.16
 homepage: https://github.com/solid-software/solid_lints/
 
 environment:
   sdk: '>=2.14.4 <4.0.0'
 
 dependencies:
-  dart_code_metrics: ^4.16.0
+  dart_code_metrics: ^5.7.3


### PR DESCRIPTION
[Issue](https://github.com/solid-software/solid_lints/issues/21)
[Issue](https://github.com/solid-software/solid_lints/issues/17)