### PR TITLE
Update Dart SDK version constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.0
+
+- **BREAKING CHANGE**:
+  - Drop support for Dart 2 while preparing for `custom_lint` support
+
 ## 0.0.18
 
 - Add rules

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.0.18
 homepage: https://github.com/solid-software/solid_lints/
 
 environment:
-  sdk: '>=2.14.4 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   # 5.7.6 has proprietary license so we will not use it

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: solid_lints
 description:
   Lints for Dart and Flutter based on software industry standards and best
   practices.
-version: 0.0.18
+version: 0.1.0
 homepage: https://github.com/solid-software/solid_lints/
 
 environment:


### PR DESCRIPTION
Bump SDK version to Dart 3 in order to allow for smooth transition from `dart_code_metrics` to `custom_lint` (which is required for `custom_lint` package).