### PR TITLE
Add number of parameters metric

### DIFF
--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,14 +1,12 @@
 include: package:solid_lints/analysis_options.yaml
 
-# Dart restricts the number of analyzers that we can use at
-# the same time, so we have to migrate everything from DCM first
-# and after that we can enable custom_lint
-# See https://github.com/dart-lang/sdk/issues/50981 for more information
-# analyzer:
-#   plugins:
-#     - custom_lint
+analyzer:
+  plugins:
+    - custom_lint
 
 custom_lint:
   rules:
     - cyclomatic_complexity_metric:
       max_complexity: 4
+    - number_of_parameters:
+      max_parameters: 2

--- a/example/lib/solid_lints_example.dart
+++ b/example/lib/solid_lints_example.dart
@@ -5,6 +5,12 @@ void main() {
 /// Sum of two numbers. Standard dart overflow rules apply.
 int sum(int p1, int p2) => p1 + p2;
 
+/// Check number of parameters fail
+/// number_of_parameters: max_parameters
+String concatenate(String a, String b, String c) {
+  return a + b + c;
+}
+
 /// Check complexity fail
 /// cyclomatic_complexity_metric: max_complexity
 int calculate() {

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -20,11 +20,6 @@ analyzer:
     # test_coverage
     - test/.test_coverage.dart
 
-  # Dart Code Metrics plugin (https://dartcodemetrics.dev/) provides many additional rules
-  # that helped to automate some pieces of our internal team code style based on the best
-  # industry practices.
-  plugins:
-    - dart_code_metrics
   language:
     # We've seen errors tied to use of implicit operations similar to the ones described in
     # https://dart.dev/guides/language/analysis-options#enabling-additional-type-checks.

--- a/lib/cyclomatic_complexity/cyclomatic_complexity_metric.dart
+++ b/lib/cyclomatic_complexity/cyclomatic_complexity_metric.dart
@@ -2,6 +2,7 @@ import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:solid_lints/cyclomatic_complexity/models/cyclomatic_complexity_parameters.dart';
 import 'package:solid_lints/cyclomatic_complexity/visitor/cyclomatic_complexity_flow_visitor.dart';
+import 'package:solid_lints/models/metric_rule.dart';
 
 /// A Complexity metric checks content of block and detects more easier solution
 class CyclomaticComplexityMetric extends DartLintRule {
@@ -9,14 +10,11 @@ class CyclomaticComplexityMetric extends DartLintRule {
   /// reaches maximum value.
   static const lintName = 'cyclomatic_complexity_metric';
 
-  /// The additional parameters for this metric.
-  final CyclomaticComplexityParameters additionalParameters;
+  /// Configuration for complexity metric rule.
+  final MetricRule<CyclomaticComplexityParameters> config;
 
   /// Creates a new instance of [CyclomaticComplexityMetric].
-  const CyclomaticComplexityMetric({
-    required this.additionalParameters,
-    required super.code,
-  });
+  CyclomaticComplexityMetric(this.config) : super(code: config.lintCode);
 
   @override
   void run(
@@ -30,7 +28,7 @@ class CyclomaticComplexityMetric extends DartLintRule {
       node.visitChildren(visitor);
 
       if (visitor.complexityEntities.length + 1 >
-          additionalParameters.maxComplexity) {
+          config.parameters.maxComplexity) {
         reporter.reportErrorForNode(code, node);
       }
     });

--- a/lib/models/metric_rule.dart
+++ b/lib/models/metric_rule.dart
@@ -1,0 +1,41 @@
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// Type definition of a value factory which allows us to map data from
+/// YAML configuration to an object of type [T].
+typedef MetricRuleValueFactory<T> = T Function(Map<String, Object?> json);
+
+/// Type definition for a problem message factory after finding a problem
+/// by a given lint.
+typedef MetricRuleProblemFactory<T> = String Function(T value);
+
+/// [MetricRule] allows us to quickly parse a lint rule and
+/// declare basic configuration for it.
+class MetricRule<T> {
+  /// Constructor for [MetricRule] model.
+  MetricRule({
+    required this.name,
+    required CustomLintConfigs configs,
+    required MetricRuleValueFactory<T> factory,
+    required MetricRuleProblemFactory<T> problemMessage,
+  })  : enabled = configs.rules[name]?.enabled ?? false,
+        parameters = factory(configs.rules[name]?.json ?? {}),
+        _problemMessageFactory = problemMessage;
+
+  /// The [LintCode] of this lint rule that represents the error.
+  final String name;
+
+  /// A flag which indicates whether this rule was enabled by the user.
+  final bool enabled;
+
+  /// Value with a configuration for a particular rule.
+  final T parameters;
+
+  /// Factory for generating error messages.
+  final MetricRuleProblemFactory<T> _problemMessageFactory;
+
+  /// [LintCode] which is generated based on the provided data.
+  LintCode get lintCode => LintCode(
+        name: name,
+        problemMessage: _problemMessageFactory(parameters),
+      );
+}

--- a/lib/number_of_parameters/models/number_of_parameters_parameters.dart
+++ b/lib/number_of_parameters/models/number_of_parameters_parameters.dart
@@ -1,0 +1,19 @@
+/// A data model class that represents the "number of parameters" input
+/// parameters.
+class NumberOfParametersParameters {
+  /// Maximum number of parameters
+  final int maxParameters;
+
+  static const _defaultMaxParameters = 2;
+
+  /// Constructor for [NumberOfParametersParameters] model
+  const NumberOfParametersParameters({
+    required this.maxParameters,
+  });
+
+  /// Method for creating from json data
+  factory NumberOfParametersParameters.fromJson(Map<String, Object?> json) =>
+      NumberOfParametersParameters(
+        maxParameters: json['max_parameters'] as int? ?? _defaultMaxParameters,
+      );
+}

--- a/lib/number_of_parameters/number_of_parameters_metric.dart
+++ b/lib/number_of_parameters/number_of_parameters_metric.dart
@@ -11,7 +11,7 @@ class NumberOfParametersMetric extends DartLintRule {
   /// parameters reaches the maximum value.
   static const lintName = 'number_of_parameters';
 
-  /// Configuration for complexity metric rule.
+  /// Configuration for number of parameters metric rule.
   final MetricRule<NumberOfParametersParameters> config;
 
   /// Creates a new instance of [NumberOfParametersMetric].

--- a/lib/number_of_parameters/number_of_parameters_metric.dart
+++ b/lib/number_of_parameters/number_of_parameters_metric.dart
@@ -1,6 +1,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:solid_lints/models/metric_rule.dart';
 import 'package:solid_lints/number_of_parameters/models/number_of_parameters_parameters.dart';
 
 /// A number of parameters metric which checks whether we didn't exceed
@@ -10,14 +11,11 @@ class NumberOfParametersMetric extends DartLintRule {
   /// parameters reaches the maximum value.
   static const lintName = 'number_of_parameters';
 
-  /// The additional parameters for this metric.
-  final NumberOfParametersParameters additionalParameters;
+  /// Configuration for complexity metric rule.
+  final MetricRule<NumberOfParametersParameters> config;
 
   /// Creates a new instance of [NumberOfParametersMetric].
-  const NumberOfParametersMetric({
-    required this.additionalParameters,
-    required super.code,
-  });
+  NumberOfParametersMetric(this.config) : super(code: config.lintCode);
 
   @override
   void run(
@@ -34,7 +32,7 @@ class NumberOfParametersMetric extends DartLintRule {
         _ => 0,
       };
 
-      if (parameters > additionalParameters.maxParameters) {
+      if (parameters > config.parameters.maxParameters) {
         reporter.reportErrorForNode(code, node);
       }
     });

--- a/lib/number_of_parameters/number_of_parameters_metric.dart
+++ b/lib/number_of_parameters/number_of_parameters_metric.dart
@@ -1,0 +1,42 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:solid_lints/number_of_parameters/models/number_of_parameters_parameters.dart';
+
+/// A number of parameters metric which checks whether we didn't exceed
+/// the maximum allowed number of parameters for a function or a method
+class NumberOfParametersMetric extends DartLintRule {
+  /// The [LintCode] of this lint rule that represents the error if number of
+  /// parameters reaches the maximum value.
+  static const lintName = 'number_of_parameters';
+
+  /// The additional parameters for this metric.
+  final NumberOfParametersParameters additionalParameters;
+
+  /// Creates a new instance of [NumberOfParametersMetric].
+  const NumberOfParametersMetric({
+    required this.additionalParameters,
+    required super.code,
+  });
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addDeclaration((node) {
+      final parameters = switch (node) {
+        (final MethodDeclaration node) =>
+          node.parameters?.parameters.length ?? 0,
+        (final FunctionDeclaration node) =>
+          node.functionExpression.parameters?.parameters.length ?? 0,
+        _ => 0,
+      };
+
+      if (parameters > additionalParameters.maxParameters) {
+        reporter.reportErrorForNode(code, node);
+      }
+    });
+  }
+}

--- a/lib/solid_lints.dart
+++ b/lib/solid_lints.dart
@@ -3,6 +3,7 @@ library solid_metrics;
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:solid_lints/cyclomatic_complexity/cyclomatic_complexity_metric.dart';
 import 'package:solid_lints/cyclomatic_complexity/models/cyclomatic_complexity_parameters.dart';
+import 'package:solid_lints/models/metric_rule.dart';
 import 'package:solid_lints/number_of_parameters/models/number_of_parameters_parameters.dart';
 import 'package:solid_lints/number_of_parameters/number_of_parameters_metric.dart';
 
@@ -15,75 +16,32 @@ class _SolidLints extends PluginBase {
   List<LintRule> getLintRules(CustomLintConfigs configs) {
     final List<LintRule> rules = [];
 
-    final cyclomaticComplexityRule =
-        configs.rules[CyclomaticComplexityMetric.lintName];
-    final cyclomaticComplexityEnabled =
-        cyclomaticComplexityRule?.enabled ?? false;
+    final cyclomaticComplexity = MetricRule<CyclomaticComplexityParameters>(
+      configs: configs,
+      name: CyclomaticComplexityMetric.lintName,
+      factory: CyclomaticComplexityParameters.fromJson,
+      problemMessage: (value) => ''
+          'Please decrease the complexity of function to '
+          'a minimum value ${value.maxComplexity}',
+    );
 
-    if (cyclomaticComplexityEnabled) {
-      final complexityMetricParameters =
-          CyclomaticComplexityParameters.fromJson(
-        _getParamsForLintRule(
-              configs,
-              CyclomaticComplexityMetric.lintName,
-            ) ??
-            {},
-      );
-
-      final lintCode = LintCode(
-        name: 'cyclomatic_complexity_metric',
-        problemMessage: ''
-            'Please decrease the complexity of function to '
-            'a minimum value ${complexityMetricParameters.maxComplexity}',
-      );
-
-      rules.add(
-        CyclomaticComplexityMetric(
-          additionalParameters: complexityMetricParameters,
-          code: lintCode,
-        ),
-      );
+    if (cyclomaticComplexity.enabled) {
+      rules.add(CyclomaticComplexityMetric(cyclomaticComplexity));
     }
 
-    final numberOfParametersRule =
-        configs.rules[NumberOfParametersMetric.lintName];
+    final numberOfParameters = MetricRule<NumberOfParametersParameters>(
+      configs: configs,
+      name: NumberOfParametersMetric.lintName,
+      factory: NumberOfParametersParameters.fromJson,
+      problemMessage: (value) => ''
+          'The maximum allowed number of parameters is ${value.maxParameters}. '
+          'Try reducing the number of parameters.',
+    );
 
-    final numberOfParametersEnabled = numberOfParametersRule?.enabled ?? false;
-
-    if (numberOfParametersEnabled) {
-      final numberOfParametersParameters =
-          NumberOfParametersParameters.fromJson(
-        _getParamsForLintRule(
-              configs,
-              NumberOfParametersMetric.lintName,
-            ) ??
-            {},
-      );
-
-      final lintCode = LintCode(
-        name: 'number_of_parameters',
-        problemMessage: ''
-            'The maximum allowed number of parameters is '
-            '${numberOfParametersParameters.maxParameters}. '
-            'Try reducing the number of parameters.',
-      );
-
-      rules.add(
-        NumberOfParametersMetric(
-          additionalParameters: numberOfParametersParameters,
-          code: lintCode,
-        ),
-      );
+    if (numberOfParameters.enabled) {
+      rules.add(NumberOfParametersMetric(numberOfParameters));
     }
 
     return rules;
-  }
-
-  /// Get params of lint rule
-  Map<String, Object?>? _getParamsForLintRule(
-    CustomLintConfigs configs,
-    String code,
-  ) {
-    return configs.rules[code]?.json;
   }
 }

--- a/lib/solid_lints.dart
+++ b/lib/solid_lints.dart
@@ -64,7 +64,8 @@ class _SolidLints extends PluginBase {
         name: 'number_of_parameters',
         problemMessage: ''
             'The maximum allowed number of parameters is '
-            '${numberOfParametersParameters.maxParameters}',
+            '${numberOfParametersParameters.maxParameters}. '
+            'Try reducing the number of parameters.',
       );
 
       rules.add(

--- a/lib/solid_lints.dart
+++ b/lib/solid_lints.dart
@@ -3,6 +3,8 @@ library solid_metrics;
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:solid_lints/cyclomatic_complexity/cyclomatic_complexity_metric.dart';
 import 'package:solid_lints/cyclomatic_complexity/models/cyclomatic_complexity_parameters.dart';
+import 'package:solid_lints/number_of_parameters/models/number_of_parameters_parameters.dart';
+import 'package:solid_lints/number_of_parameters/number_of_parameters_metric.dart';
 
 /// creates plugin
 PluginBase createPlugin() => _SolidLints();
@@ -38,6 +40,36 @@ class _SolidLints extends PluginBase {
       rules.add(
         CyclomaticComplexityMetric(
           additionalParameters: complexityMetricParameters,
+          code: lintCode,
+        ),
+      );
+    }
+
+    final numberOfParametersRule =
+        configs.rules[NumberOfParametersMetric.lintName];
+
+    final numberOfParametersEnabled = numberOfParametersRule?.enabled ?? false;
+
+    if (numberOfParametersEnabled) {
+      final numberOfParametersParameters =
+          NumberOfParametersParameters.fromJson(
+        _getParamsForLintRule(
+              configs,
+              NumberOfParametersMetric.lintName,
+            ) ??
+            {},
+      );
+
+      final lintCode = LintCode(
+        name: 'number_of_parameters',
+        problemMessage: ''
+            'The maximum allowed number of parameters is '
+            '${numberOfParametersParameters.maxParameters}',
+      );
+
+      rules.add(
+        NumberOfParametersMetric(
+          additionalParameters: numberOfParametersParameters,
           code: lintCode,
         ),
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,5 +11,3 @@ environment:
 dependencies:
   analyzer: ^5.12.0
   custom_lint_builder: ^0.5.0
-  # 5.7.6 has proprietary license so we will not use it
-  dart_code_metrics: '>=5.7.3 <=5.7.5'


### PR DESCRIPTION
PR which allows the capability to check whether we excedeed the maximum allowed number of parameters. As a first new lint it also contains a proposal for organising the code. 

**One thing to consider**: In my opinion having custom models for lints is not necessary, operating on primitives like:
```yaml
custom_lint:
  rules:
    - cyclomatic_complexity_metric: 4
    - number_of_parameters: 2
```
should be good enough for us.

Current configuration for custom lints looks like that:
```yaml
custom_lint:
  rules:
    - cyclomatic_complexity_metric:
      max_complexity: 4
    - number_of_parameters:
      max_parameters: 2
```
and requires custom models for each rule. It feels like an overkill for me, because we will end up with a bunch of models that have only one field in them.