### PR TITLE
Add avoid_global_state lint

### DIFF
--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -13,3 +13,4 @@ custom_lint:
     - function_lines_of_code:
       max_lines: 50
     - avoid_late_keyword
+    - avoid_global_state

--- a/example/test/avoid_global_state_test.dart
+++ b/example/test/avoid_global_state_test.dart
@@ -1,0 +1,12 @@
+// ignore_for_file: type_annotate_public_apis
+
+/// Check global mutable variable fail
+/// `avoid_global_state`
+
+// expect_lint: avoid_global_state
+var globalMutable = 0;
+
+class Test {
+  // expect_lint: avoid_global_state
+  static int globalMutable = 0;
+}

--- a/example/test/avoid_late_keyword_test.dart
+++ b/example/test/avoid_late_keyword_test.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: prefer_const_declarations, unused_local_variable
+// ignore_for_file: avoid_global_state
 
 /// Check "late" keyword fail
 ///

--- a/lib/lints/avoid_global_state/avoid_global_state_rule.dart
+++ b/lib/lints/avoid_global_state/avoid_global_state_rule.dart
@@ -1,0 +1,28 @@
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A global state rule which forbids using variables
+/// that can be globally modified.
+class AvoidGlobalStateRule extends DartLintRule {
+  /// The [LintCode] of this lint rule that represents
+  /// the error whether we use global state.
+  static const lintName = 'avoid_global_state';
+
+  /// Creates a new instance of [AvoidGlobalStateRule].
+  const AvoidGlobalStateRule({required super.code});
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addVariableDeclaration((node) {
+      final isPrivate = node.declaredElement?.isPrivate ?? false;
+
+      if (!isPrivate && !node.isFinal && !node.isConst) {
+        reporter.reportErrorForNode(code, node);
+      }
+    });
+  }
+}

--- a/lib/lints/function_lines_of_code/function_lines_of_code_metric.dart
+++ b/lib/lints/function_lines_of_code/function_lines_of_code_metric.dart
@@ -5,7 +5,7 @@ import 'package:solid_lints/lints/function_lines_of_code/visitor/function_lines_
 import 'package:solid_lints/models/metric_rule.dart';
 
 /// A number of lines metric which checks whether we didn't exceed
-/// the maximum allowed number of lines for a file
+/// the maximum allowed number of lines for a function.
 class FunctionLinesOfCodeMetric extends DartLintRule {
   /// The [LintCode] of this lint rule that represents the error if number of
   /// parameters reaches the maximum value.

--- a/lib/lints/function_lines_of_code/models/function_lines_of_code_parameters.dart
+++ b/lib/lints/function_lines_of_code/models/function_lines_of_code_parameters.dart
@@ -1,4 +1,4 @@
-/// A data model class that represents the "source lines of code" input
+/// A data model class that represents the "function lines of code" input
 /// parameters.
 class FunctionLinesOfCodeParameters {
   /// Maximum number of lines

--- a/lib/models/metric_rule.dart
+++ b/lib/models/metric_rule.dart
@@ -10,7 +10,7 @@ typedef MetricRuleProblemFactory<T> = String Function(T value);
 
 /// [MetricRule] allows us to quickly parse a lint rule and
 /// declare basic configuration for it.
-class MetricRule<T> {
+class MetricRule<T extends Object?> {
   /// Constructor for [MetricRule] model.
   MetricRule({
     required this.name,

--- a/lib/solid_lints.dart
+++ b/lib/solid_lints.dart
@@ -1,6 +1,7 @@
 library solid_metrics;
 
 import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:solid_lints/lints/avoid_global_state/avoid_global_state_rule.dart';
 import 'package:solid_lints/lints/avoid_late_keyword/avoid_late_keyword_rule.dart';
 import 'package:solid_lints/lints/cyclomatic_complexity/cyclomatic_complexity_metric.dart';
 import 'package:solid_lints/lints/cyclomatic_complexity/models/cyclomatic_complexity_parameters.dart';
@@ -68,6 +69,16 @@ class _SolidLints extends PluginBase {
 
     if (avoidLateKeyword.enabled) {
       rules.add(AvoidLateKeywordRule(code: avoidLateKeyword.lintCode));
+    }
+
+    final avoidGlobalState = MetricRule(
+      configs: configs,
+      name: AvoidGlobalStateRule.lintName,
+      problemMessage: (_) => 'Avoid variables that can be globally mutated.',
+    );
+
+    if (avoidGlobalState.enabled) {
+      rules.add(AvoidGlobalStateRule(code: avoidGlobalState.lintCode));
     }
 
     return rules;


### PR DESCRIPTION
Those `MetricRule` definitions should probably be moved to a separate place later on (maybe to associated lints?). It takes too much space in the main file considering how many lints we have to implement. 

cc: @solid-yuriiprykhodko 