### PR TITLE
Add the 'double-literal-format' rule

### DIFF
--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -16,3 +16,4 @@ custom_lint:
     - avoid_late_keyword
     - avoid_global_state
     - avoid_returning_widgets
+    - double-literal-format

--- a/example/test/double_literal_format_test.dart
+++ b/example/test/double_literal_format_test.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: avoid_global_state
 // ignore_for_file: type_annotate_public_apis
-// ignore_for_file:unused_local_variable
+// ignore_for_file: unused_local_variable
 
 /// Check the `double-literal-format` rule
 
@@ -8,6 +8,8 @@
 var badA = 05.23;
 var goodA = 5.23;
 var stringA = '05.23';
+
+var intA = 00;
 
 // expect_lint: double-literal-format
 double badB = -01.2;

--- a/example/test/double_literal_format_test.dart
+++ b/example/test/double_literal_format_test.dart
@@ -1,0 +1,16 @@
+// ignore_for_file: avoid_global_state
+
+/// Check `double-literal-format` rule
+
+// expect_lint: double-literal-format
+var a = 05.23;
+
+class DoubleLiteralFormatTest {
+  // expect_lint: double-literal-format
+  var b = .16e+5;
+
+  void someMethod() {
+    // expect_lint: double-literal-format
+    const c = -0.250;
+  }
+}

--- a/example/test/double_literal_format_test.dart
+++ b/example/test/double_literal_format_test.dart
@@ -9,7 +9,7 @@ var badA = 05.23;
 var goodA = 5.23;
 var stringA = '05.23';
 
-var intA = 00;
+var intA = 0;
 
 // expect_lint: double-literal-format
 double badB = -01.2;
@@ -33,6 +33,6 @@ class DoubleLiteralFormatTest {
     const badA = -0.250;
     const goodA = -0.25;
     // expect_lint: double-literal-format
-    const goodB = 0.160e+5;
+    const badB = 0.160e+5;
   }
 }

--- a/example/test/double_literal_format_test.dart
+++ b/example/test/double_literal_format_test.dart
@@ -1,16 +1,36 @@
 // ignore_for_file: avoid_global_state
+// ignore_for_file: type_annotate_public_apis
+// ignore_for_file:unused_local_variable
 
-/// Check `double-literal-format` rule
+/// Check the `double-literal-format` rule
 
 // expect_lint: double-literal-format
-var a = 05.23;
+var badA = 05.23;
+var goodA = 5.23;
+var stringA = '05.23';
+
+// expect_lint: double-literal-format
+double badB = -01.2;
+double goodB = -1.2;
+
+// expect_lint: double-literal-format
+double badC = -001.2;
+
+// expect_lint: double-literal-format
+double badExpr = 5.23 + 05.23;
+
+double goodExpr = 5.23 + 5.23;
 
 class DoubleLiteralFormatTest {
   // expect_lint: double-literal-format
-  var b = .16e+5;
+  var badA = .16e+5;
+  var goodA = 0.16e+5;
 
   void someMethod() {
     // expect_lint: double-literal-format
-    const c = -0.250;
+    const badA = -0.250;
+    const goodA = -0.25;
+    // expect_lint: double-literal-format
+    const goodB = 0.160e+5;
   }
 }

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -152,13 +152,14 @@ linter:
     - implementation_imports
     # deprecated rule in Flutter 3.7
     # - invariant_booleans
-    - iterable_contains_unrelated_type
+    # - iterable_contains_unrelated_type
+    - collection_methods_unrelated_type
     - join_return_with_assignment
     - leading_newlines_in_multiline_strings
     - library_names
     - library_prefixes
     - lines_longer_than_80_chars
-    - list_remove_unrelated_type
+    # - list_remove_unrelated_type
     - literal_only_boolean_expressions
     - no_adjacent_strings_in_list
     - no_duplicate_case_values

--- a/lib/lints/double_literal_format/double_literal_format_fix.dart
+++ b/lib/lints/double_literal_format/double_literal_format_fix.dart
@@ -1,0 +1,64 @@
+part of 'double_literal_format_rule.dart';
+
+/// A Quick fix for `double-literal-format` rule
+/// Suggests the correct value for an issue
+class _DoubleLiteralFormatFix extends DartFix {
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ChangeReporter reporter,
+    CustomLintContext context,
+    AnalysisError analysisError,
+    List<AnalysisError> others,
+  ) {
+    context.registry.addDoubleLiteral((node) {
+      // checks that the literal declaration is where our warning is located
+      if (!analysisError.sourceRange.intersects(node.sourceRange)) return;
+
+      final lexeme = node.literal.lexeme;
+      String? correctLexeme;
+
+      if (lexeme.hasLeadingZero) {
+        correctLexeme = _correctLeadingZeroLexeme(lexeme);
+      } else if (lexeme.hasLeadingDecimalPoint) {
+        correctLexeme = _correctLeadingDecimalPointLexeme(lexeme);
+      } else if (lexeme.hasTrailingZero) {
+        correctLexeme = _correctTrailingZeroLexeme(lexeme);
+      }
+
+      if (correctLexeme != null) {
+        final changeBuilder = reporter.createChangeBuilder(
+          message: 'Replace by $correctLexeme',
+          priority: 1,
+        );
+
+        changeBuilder.addDartFileEdit((builder) {
+          builder.addSimpleReplacement(
+            SourceRange(node.offset, node.length),
+            correctLexeme!,
+          );
+        });
+      }
+    });
+  }
+
+  String _correctLeadingZeroLexeme(String lexeme) => !lexeme.hasLeadingZero
+      ? lexeme
+      : _correctLeadingZeroLexeme(lexeme.substring(1));
+
+  String _correctLeadingDecimalPointLexeme(String lexeme) => '0$lexeme';
+
+  String _correctTrailingZeroLexeme(String lexeme) {
+    if (!lexeme.hasTrailingZero) {
+      return lexeme;
+    } else {
+      final mantissa = lexeme.split('e').first;
+      return _correctTrailingZeroLexeme(
+        lexeme.replaceFirst(
+          mantissa,
+          mantissa.substring(0, mantissa.length - 1),
+        ),
+      );
+    }
+  }
+}

--- a/lib/lints/double_literal_format/double_literal_format_rule.dart
+++ b/lib/lints/double_literal_format/double_literal_format_rule.dart
@@ -49,7 +49,7 @@ class DoubleLiteralFormatRule extends SolidLintRule {
     final rule = RuleConfig(
       configs: configs,
       name: lintName,
-      problemMessage: (_) => 'Bad formatted double literal',
+      problemMessage: (_) => 'Double literal formatting issue',
     );
 
     return DoubleLiteralFormatRule._(rule);
@@ -64,27 +64,27 @@ class DoubleLiteralFormatRule extends SolidLintRule {
     context.registry.addDoubleLiteral((node) {
       final lexeme = node.literal.lexeme;
 
-      if (_isLeadingZero(lexeme)) {
+      if (_hasLeadingZero(lexeme)) {
         reporter.reportErrorForNode(_leadingZeroCode, node);
         return;
       }
-      if (_isLeadingDecimal(lexeme)) {
+      if (_hasLeadingDecimalPoint(lexeme)) {
         reporter.reportErrorForNode(_leadingDecimalCode, node);
         return;
       }
-      if (_isTrailingZero(lexeme)) {
+      if (_hasTrailingZero(lexeme)) {
         reporter.reportErrorForNode(_trailingZeroCode, node);
         return;
       }
     });
   }
 
-  bool _isLeadingZero(String lexeme) =>
+  bool _hasLeadingZero(String lexeme) =>
       lexeme.startsWith('0') && lexeme[1] != '.';
 
-  bool _isLeadingDecimal(String lexeme) => lexeme.startsWith('.');
+  bool _hasLeadingDecimalPoint(String lexeme) => lexeme.startsWith('.');
 
-  bool _isTrailingZero(String lexeme) {
+  bool _hasTrailingZero(String lexeme) {
     final mantissa = lexeme.split('e').first;
 
     return mantissa.contains('.') &&

--- a/lib/lints/double_literal_format/double_literal_format_rule.dart
+++ b/lib/lints/double_literal_format/double_literal_format_rule.dart
@@ -1,0 +1,46 @@
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:solid_lints/models/rule_config.dart';
+import 'package:solid_lints/models/solid_lint_rule.dart';
+
+/// A `double-literal-format` rule which
+/// checks that double literals should begin with 0. instead of just .,
+/// and should not end with a trailing 0.
+/// BAD:
+/// var a = 05.23, b = .16e+5, c = -0.250, d = -0.400e-5;
+/// GOOD:
+/// var a = 5.23, b = 0.16e+5, c = -0.25, d = -0.4e-5;
+class DoubleLiteralFormatRule extends SolidLintRule {
+  /// The [LintCode] of this lint rule that represents
+  /// the error whether we use global state.
+  static const lintName = 'double-literal-format';
+
+  DoubleLiteralFormatRule._(super.config);
+
+  /// Creates a new instance of [DoubleLiteralFormatRule]
+  /// based on the lint configuration.
+  factory DoubleLiteralFormatRule.createRule(CustomLintConfigs configs) {
+    final rule = RuleConfig(
+      configs: configs,
+      name: lintName,
+      problemMessage: (_) => ''
+          'Double literals should start with `0.` instead of `.`'
+          'Double literals should not end with a trailing `0`',
+    );
+
+    return DoubleLiteralFormatRule._(rule);
+  }
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    // TODO: implement run
+    context.registry.addDoubleLiteral((node) {
+      print('CHECK double rule $node | ${node.literal}');
+      // reporter.reportErrorForNode(code, node);
+    });
+  }
+}

--- a/lib/lints/double_literal_format/double_literal_format_rule.dart
+++ b/lib/lints/double_literal_format/double_literal_format_rule.dart
@@ -1,7 +1,12 @@
+import 'package:analyzer/error/error.dart';
 import 'package:analyzer/error/listener.dart';
+import 'package:analyzer/source/source_range.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:solid_lints/models/rule_config.dart';
 import 'package:solid_lints/models/solid_lint_rule.dart';
+
+part 'double_literal_format_fix.dart';
+part 'double_literal_format_utils.dart';
 
 /// A `double-literal-format` rule which
 /// checks that double literals should begin with 0. instead of just .,
@@ -64,31 +69,21 @@ class DoubleLiteralFormatRule extends SolidLintRule {
     context.registry.addDoubleLiteral((node) {
       final lexeme = node.literal.lexeme;
 
-      if (_hasLeadingZero(lexeme)) {
+      if (lexeme.hasLeadingZero) {
         reporter.reportErrorForNode(_leadingZeroCode, node);
         return;
       }
-      if (_hasLeadingDecimalPoint(lexeme)) {
+      if (lexeme.hasLeadingDecimalPoint) {
         reporter.reportErrorForNode(_leadingDecimalCode, node);
         return;
       }
-      if (_hasTrailingZero(lexeme)) {
+      if (lexeme.hasTrailingZero) {
         reporter.reportErrorForNode(_trailingZeroCode, node);
         return;
       }
     });
   }
 
-  bool _hasLeadingZero(String lexeme) =>
-      lexeme.startsWith('0') && lexeme[1] != '.';
-
-  bool _hasLeadingDecimalPoint(String lexeme) => lexeme.startsWith('.');
-
-  bool _hasTrailingZero(String lexeme) {
-    final mantissa = lexeme.split('e').first;
-
-    return mantissa.contains('.') &&
-        mantissa.endsWith('0') &&
-        mantissa.split('.').last != '0';
-  }
+  @override
+  List<Fix> getFixes() => [_DoubleLiteralFormatFix()];
 }

--- a/lib/lints/double_literal_format/double_literal_format_rule.dart
+++ b/lib/lints/double_literal_format/double_literal_format_rule.dart
@@ -12,8 +12,34 @@ import 'package:solid_lints/models/solid_lint_rule.dart';
 /// var a = 5.23, b = 0.16e+5, c = -0.25, d = -0.4e-5;
 class DoubleLiteralFormatRule extends SolidLintRule {
   /// The [LintCode] of this lint rule that represents
-  /// the error whether we use global state.
+  /// the error whether we use bad formatted double literals.
   static const lintName = 'double-literal-format';
+
+  // Use different messages for different issues
+  /// The [LintCode] of this lint rule that represents
+  /// the error whether we use double literals with a redundant leading 0.
+  static const _leadingZeroCode = LintCode(
+    name: lintName,
+    problemMessage: "Double literals shouldn't have redundant leading `0`.",
+    correctionMessage: "Remove redundant leading `0`.",
+  );
+
+  /// The [LintCode] of this lint rule that represents
+  /// the error whether we use double literals with a leading decimal point.
+  static const _leadingDecimalCode = LintCode(
+    name: lintName,
+    problemMessage:
+        "Double literals shouldn't begin with the decimal point `.`.",
+    correctionMessage: "Add missing leading `0`.",
+  );
+
+  /// The [LintCode] of this lint rule that represents
+  /// the error whether we use double literals with a trailing 0.
+  static const _trailingZeroCode = LintCode(
+    name: lintName,
+    problemMessage: "Double literals should not end with a trailing `0`.",
+    correctionMessage: "Remove redundant trailing `0`.",
+  );
 
   DoubleLiteralFormatRule._(super.config);
 
@@ -23,9 +49,7 @@ class DoubleLiteralFormatRule extends SolidLintRule {
     final rule = RuleConfig(
       configs: configs,
       name: lintName,
-      problemMessage: (_) => ''
-          'Double literals should start with `0.` instead of `.`'
-          'Double literals should not end with a trailing `0`',
+      problemMessage: (_) => 'Bad formatted double literal',
     );
 
     return DoubleLiteralFormatRule._(rule);
@@ -37,10 +61,34 @@ class DoubleLiteralFormatRule extends SolidLintRule {
     ErrorReporter reporter,
     CustomLintContext context,
   ) {
-    // TODO: implement run
     context.registry.addDoubleLiteral((node) {
-      print('CHECK double rule $node | ${node.literal}');
-      // reporter.reportErrorForNode(code, node);
+      final lexeme = node.literal.lexeme;
+
+      if (_isLeadingZero(lexeme)) {
+        reporter.reportErrorForNode(_leadingZeroCode, node);
+        return;
+      }
+      if (_isLeadingDecimal(lexeme)) {
+        reporter.reportErrorForNode(_leadingDecimalCode, node);
+        return;
+      }
+      if (_isTrailingZero(lexeme)) {
+        reporter.reportErrorForNode(_trailingZeroCode, node);
+        return;
+      }
     });
+  }
+
+  bool _isLeadingZero(String lexeme) =>
+      lexeme.startsWith('0') && lexeme[1] != '.';
+
+  bool _isLeadingDecimal(String lexeme) => lexeme.startsWith('.');
+
+  bool _isTrailingZero(String lexeme) {
+    final mantissa = lexeme.split('e').first;
+
+    return mantissa.contains('.') &&
+        mantissa.endsWith('0') &&
+        mantissa.split('.').last != '0';
   }
 }

--- a/lib/lints/double_literal_format/double_literal_format_utils.dart
+++ b/lib/lints/double_literal_format/double_literal_format_utils.dart
@@ -1,0 +1,19 @@
+part of 'double_literal_format_rule.dart';
+
+/// Useful extensions for double literals representation
+extension _StringDoubleEx on String {
+  /// Returns true if a double literal starts with 00
+  bool get hasLeadingZero => startsWith('0') && this[1] != '.';
+
+  /// Returns true if a double literal starts with .
+  bool get hasLeadingDecimalPoint => startsWith('.');
+
+  /// Returns true if a mantissa of a double literal ends with 0
+  bool get hasTrailingZero {
+    final mantissa = split('e').first;
+
+    return mantissa.contains('.') &&
+        mantissa.endsWith('0') &&
+        mantissa.split('.').last != '0';
+  }
+}

--- a/lib/solid_lints.dart
+++ b/lib/solid_lints.dart
@@ -6,6 +6,7 @@ import 'package:solid_lints/lints/avoid_late_keyword/avoid_late_keyword_rule.dar
 import 'package:solid_lints/lints/avoid_non_null_assertion/avoid_non_null_assertion_rule.dart';
 import 'package:solid_lints/lints/avoid_returning_widgets/avoid_returning_widgets_rule.dart';
 import 'package:solid_lints/lints/cyclomatic_complexity/cyclomatic_complexity_metric.dart';
+import 'package:solid_lints/lints/double_literal_format/double_literal_format_rule.dart';
 import 'package:solid_lints/lints/function_lines_of_code/function_lines_of_code_metric.dart';
 import 'package:solid_lints/lints/number_of_parameters/number_of_parameters_metric.dart';
 import 'package:solid_lints/models/solid_lint_rule.dart';
@@ -25,6 +26,7 @@ class _SolidLints extends PluginBase {
       AvoidLateKeywordRule.createRule(configs),
       AvoidGlobalStateRule.createRule(configs),
       AvoidReturningWidgetsRule.createRule(configs),
+      DoubleLiteralFormatRule.createRule(configs),
     ];
 
     // Return only enabled rules


### PR DESCRIPTION
1. Implemented the 'double-literal-format' rule
2. Added a test for the 'double-literal-format' rule

![double-literal-format-rule](https://github.com/solid-software/solid_lints/assets/920953/29b0d964-98f9-41de-b639-7f9a2e1e4106)
