### PR TITLE
Remove deprecated members

### DIFF
--- a/lib/src/common/parameters/excluded_identifiers_list_parameter.dart
+++ b/lib/src/common/parameters/excluded_identifiers_list_parameter.dart
@@ -55,7 +55,7 @@ class ExcludedIdentifiersListParameter {
 
   /// Returns whether the target node should be ignored during analysis.
   bool shouldIgnore(Declaration node) {
-    final declarationName = node.declaredElement?.name;
+    final declarationName = node.declaredFragment?.name2;
 
     final excludedItem = exclude.firstWhereOrNull(
       (e) {

--- a/lib/src/lints/avoid_debug_print_in_release/avoid_debug_print_in_release_rule.dart
+++ b/lib/src/lints/avoid_debug_print_in_release/avoid_debug_print_in_release_rule.dart
@@ -159,11 +159,10 @@ your `debugPrint` call in a `!kReleaseMode` check.""",
       case PrefixedIdentifier():
         final prefix = node.prefix.name;
         name = node.name.replaceAll('$prefix.', '');
-        sourcePath = node.staticElement?.librarySource?.uri.toString() ?? '';
-
+        sourcePath = node.element?.library2?.uri.toString() ?? '';
       case SimpleIdentifier():
         name = node.name;
-        sourcePath = node.staticElement?.librarySource?.uri.toString() ?? '';
+        sourcePath = node.element?.library2?.uri.toString() ?? '';
 
       default:
         return false;
@@ -194,10 +193,10 @@ your `debugPrint` call in a `!kReleaseMode` check.""",
         final prefix = node.prefix.name;
 
         name = node.name.replaceAll('$prefix.', '');
-        sourcePath = node.staticElement?.librarySource?.uri.toString() ?? '';
+        sourcePath = node.element?.library2?.uri.toString() ?? '';
       case SimpleIdentifier():
         name = node.name;
-        sourcePath = node.staticElement?.librarySource?.uri.toString() ?? '';
+        sourcePath = node.element?.library2?.uri.toString() ?? '';
       default:
         return false;
     }

--- a/lib/src/lints/avoid_final_with_getter/visitors/avoid_final_with_getter_visitor.dart
+++ b/lib/src/lints/avoid_final_with_getter/visitors/avoid_final_with_getter_visitor.dart
@@ -1,6 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:solid_lints/src/lints/avoid_final_with_getter/visitors/getter_variable_visitor.dart';
 
 /// A visitor that checks for final private fields with getters.
@@ -16,9 +16,11 @@ class AvoidFinalWithGetterVisitor extends RecursiveAstVisitor<void> {
     if (node
         case MethodDeclaration(
           isGetter: true,
-          declaredElement: ExecutableElement(
-            isAbstract: false,
-            isPublic: true,
+          declaredFragment: ExecutableFragment(
+            element: ExecutableElement2(
+              isAbstract: false,
+              isPublic: true,
+            )
           )
         )) {
       final visitor = GetterVariableVisitor(node);

--- a/lib/src/lints/avoid_final_with_getter/visitors/getter_variable_visitor.dart
+++ b/lib/src/lints/avoid_final_with_getter/visitors/getter_variable_visitor.dart
@@ -13,7 +13,6 @@ class GetterVariableVisitor extends RecursiveAstVisitor<void> {
       : _getterId = getter.getterReferenceId;
 
   /// Is there a variable associated with the getter
-
   VariableDeclaration? get variable => _variable;
 
   @override

--- a/lib/src/lints/avoid_global_state/avoid_global_state_rule.dart
+++ b/lib/src/lints/avoid_global_state/avoid_global_state_rule.dart
@@ -77,7 +77,7 @@ class AvoidGlobalStateRule extends SolidLintRule {
 extension on VariableDeclaration {
   bool get isMutable => !isFinal && !isConst;
 
-  bool get isPrivate => declaredElement?.isPrivate ?? false;
+  bool get isPrivate => declaredElement2?.isPrivate ?? false;
 
   bool get isPublicMutable => isMutable && !isPrivate;
 }

--- a/lib/src/lints/avoid_late_keyword/avoid_late_keyword_rule.dart
+++ b/lib/src/lints/avoid_late_keyword/avoid_late_keyword_rule.dart
@@ -82,7 +82,7 @@ class AvoidLateKeywordRule extends SolidLintRule<AvoidLateKeywordParameters> {
   }
 
   bool _shouldLint(VariableDeclaration node) {
-    final isLateDeclaration = node.declaredElement?.isLate ?? false;
+    final isLateDeclaration = node.isLate;
     if (!isLateDeclaration) return false;
 
     final hasIgnoredType = _hasIgnoredType(node);
@@ -99,7 +99,7 @@ class AvoidLateKeywordRule extends SolidLintRule<AvoidLateKeywordParameters> {
     final ignoredTypes = config.parameters.ignoredTypes.toSet();
     if (ignoredTypes.isEmpty) return false;
 
-    final variableType = node.declaredElement?.type;
+    final variableType = node.declaredFragment?.element.type;
     if (variableType == null) return false;
 
     return variableType.hasIgnoredType(

--- a/lib/src/lints/avoid_returning_widgets/avoid_returning_widgets_rule.dart
+++ b/lib/src/lints/avoid_returning_widgets/avoid_returning_widgets_rule.dart
@@ -54,6 +54,7 @@ class AvoidReturningWidgetsRule
   /// This lint rule represents
   /// the error whether we return a widget.
   static const lintName = 'avoid_returning_widgets';
+  static const _override = 'override';
 
   AvoidReturningWidgetsRule._(super.config);
 
@@ -97,7 +98,16 @@ class AvoidReturningWidgetsRule
 
       final isIgnored = config.parameters.exclude.shouldIgnore(node);
 
-      final isOverriden = node.declaredElement?.hasOverride ?? false;
+      final isOverriden = switch (node) {
+        FunctionDeclaration(:final functionExpression) =>
+          functionExpression.parent is MethodDeclaration &&
+              (functionExpression.parent! as MethodDeclaration)
+                  .metadata
+                  .any((m) => m.name.name == _override),
+        MethodDeclaration(:final metadata) =>
+          metadata.any((m) => m.name.name == _override),
+        _ => false,
+      };
 
       if (isWidgetReturned && !isOverriden && !isIgnored) {
         reporter.atNode(node, code);

--- a/lib/src/lints/avoid_unrelated_type_assertions/visitors/avoid_unrelated_type_assertions_visitor.dart
+++ b/lib/src/lints/avoid_unrelated_type_assertions/visitors/avoid_unrelated_type_assertions_visitor.dart
@@ -97,7 +97,7 @@ class AvoidUnrelatedTypeAssertionsVisitor extends RecursiveAstVisitor<void> {
             ? objectType.typeArguments.first
             : objectType;
 
-    if ((correctObjectType.element == castedType.element) ||
+    if ((correctObjectType.element3 == castedType.element3) ||
         castedType is DynamicType ||
         correctObjectType is DynamicType ||
         _isObjectAndEnum(correctObjectType, castedType)) {
@@ -106,7 +106,7 @@ class AvoidUnrelatedTypeAssertionsVisitor extends RecursiveAstVisitor<void> {
 
     if (correctObjectType is InterfaceType) {
       return correctObjectType.allSupertypes
-          .firstWhereOrNull((value) => value.element == castedType.element);
+          .firstWhereOrNull((value) => value.element3 == castedType.element3);
     }
 
     return null;
@@ -144,5 +144,5 @@ class AvoidUnrelatedTypeAssertionsVisitor extends RecursiveAstVisitor<void> {
 
   bool _isObjectAndEnum(DartType objectType, DartType castedType) =>
       objectType.isDartCoreObject &&
-      castedType.element?.kind == ElementKind.ENUM;
+      castedType.element3?.kind == ElementKind.ENUM;
 }

--- a/lib/src/lints/avoid_unused_parameters/visitors/avoid_unused_parameters_visitor.dart
+++ b/lib/src/lints/avoid_unused_parameters/visitors/avoid_unused_parameters_visitor.dart
@@ -23,7 +23,7 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:collection/collection.dart';
 import 'package:solid_lints/src/utils/node_utils.dart';
 import 'package:solid_lints/src/utils/parameter_utils.dart';
@@ -129,7 +129,7 @@ class AvoidUnusedParametersVisitor extends RecursiveAstVisitor<void> {
     for (final parameter in parameters) {
       final name = parameter.name;
       final isPresentInAll = allIdentifierElements.contains(
-        parameter.declaredElement,
+        parameter.declaredFragment?.element.baseElement.nonSynthetic2,
       );
 
       /// Variables declared and initialized as 'Foo(this.param)'
@@ -172,13 +172,13 @@ class AvoidUnusedParametersVisitor extends RecursiveAstVisitor<void> {
 }
 
 class _IdentifiersVisitor extends RecursiveAstVisitor<void> {
-  final elements = <Element>{};
+  final elements = <Element2>{};
 
   @override
   void visitSimpleIdentifier(SimpleIdentifier node) {
     super.visitSimpleIdentifier(node);
 
-    final element = node.staticElement;
+    final element = node.element;
     if (element != null) {
       elements.add(element);
     }
@@ -195,7 +195,7 @@ class _InvocationsVisitor extends RecursiveAstVisitor<void> {
   @override
   void visitSimpleIdentifier(SimpleIdentifier node) {
     if (node.name == methodName &&
-        node.staticElement is MethodElement &&
+        node.element is MethodElement2 &&
         node.parent is ArgumentList) {
       hasTearOffInvocations = true;
     }

--- a/lib/src/lints/avoid_using_api/avoid_using_api_linter.dart
+++ b/lib/src/lints/avoid_using_api/avoid_using_api_linter.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:collection/collection.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
@@ -94,8 +94,10 @@ class AvoidUsingApiLinter {
         return;
       }
 
-      switch (node.staticElement) {
-        case FunctionElement() || PropertyAccessorElement():
+      switch (node.element) {
+        case LocalFunctionElement() ||
+              TopLevelFunctionElement() ||
+              PropertyAccessorElement2():
           reporter.atNode(node, entryCode);
       }
     });
@@ -108,13 +110,13 @@ class AvoidUsingApiLinter {
     String source,
   ) {
     context.registry.addVariableDeclaration((node) {
-      final typeName = node.declaredElement?.type.element?.name;
+      final typeName = node.declaredElement2?.type.element3?.name3;
       if (typeName != className) {
         return;
       }
 
       final sourcePath =
-          node.declaredElement?.type.element?.librarySource?.uri.toString();
+          node.declaredElement2?.type.element3?.library2?.uri.toString();
       if (sourcePath == null || !_matchesSource(sourcePath, source)) {
         return;
       }
@@ -136,25 +138,24 @@ class AvoidUsingApiLinter {
         case InstanceCreationExpression(:final staticType?):
         case SimpleIdentifier(:final staticType?):
           final parentSourcePath =
-              staticType.element?.librarySource?.uri.toString() ??
-                  node.sourceUrl;
+              staticType.element3?.library2?.uri.toString() ?? node.sourceUrl;
           if (parentSourcePath == null ||
               !_matchesSource(parentSourcePath, source)) {
             return;
           }
 
-          final parentTypeName = staticType.element?.name;
+          final parentTypeName = staticType.element3?.name3;
           if (parentTypeName != className) {
             return;
           }
-        case SimpleIdentifier(:final staticElement?):
+        case SimpleIdentifier(:final element?):
           final parentSourcePath =
-              staticElement.librarySource?.uri.toString() ?? node.sourceUrl;
+              element.library2?.uri.toString() ?? node.sourceUrl;
           if (parentSourcePath == null ||
               !_matchesSource(parentSourcePath, source)) {
             return;
           }
-          final parentElementName = staticElement.name;
+          final parentElementName = element.name3;
           if (parentElementName != className) {
             return;
           }
@@ -214,7 +215,7 @@ class AvoidUsingApiLinter {
       switch (entityBeforeNode) {
         case InstanceCreationExpression(:final staticType?):
         case SimpleIdentifier(:final staticType?):
-          final parentTypeName = staticType.element?.name;
+          final parentTypeName = staticType.element3?.name3;
           if (parentTypeName != className) {
             return;
           }
@@ -223,8 +224,8 @@ class AvoidUsingApiLinter {
             node.parent ?? node,
             entryCode,
           );
-        case SimpleIdentifier(:final staticElement?):
-          final parentElementName = staticElement.name;
+        case SimpleIdentifier(:final element?):
+          final parentElementName = element.name3;
           if (parentElementName != className) {
             return;
           }
@@ -233,8 +234,8 @@ class AvoidUsingApiLinter {
             node.parent ?? node,
             entryCode,
           );
-        case NamedType(:final element?):
-          final parentTypeName = element.name;
+        case NamedType(:final element2?):
+          final parentTypeName = element2.name3;
           if (parentTypeName != className) {
             return;
           }
@@ -250,13 +251,13 @@ class AvoidUsingApiLinter {
       final methodName = node.methodName.name;
       if (methodName != identifier) return;
 
-      final enclosingElement = node.methodName.staticElement?.enclosingElement3;
-      if (enclosingElement is! ExtensionElement ||
-          enclosingElement.name != className) {
+      final enclosingElement = node.methodName.element?.enclosingElement2;
+      if (enclosingElement is! ExtensionElement2 ||
+          enclosingElement.name3 != className) {
         return;
       }
 
-      final sourcePath = enclosingElement.librarySource.uri.toString();
+      final sourcePath = enclosingElement.library2.uri.toString();
       if (!_matchesSource(sourcePath, source)) {
         return;
       }
@@ -268,13 +269,13 @@ class AvoidUsingApiLinter {
       final propertyName = node.identifier.name;
       if (propertyName != identifier) return;
 
-      final enclosingElement = node.identifier.staticElement?.enclosingElement3;
-      if (enclosingElement is! ExtensionElement ||
-          enclosingElement.name != className) {
+      final enclosingElement = node.identifier.element?.enclosingElement2;
+      if (enclosingElement is! ExtensionElement2 ||
+          enclosingElement.name3 != className) {
         return;
       }
 
-      final sourcePath = enclosingElement.librarySource.uri.toString();
+      final sourcePath = enclosingElement.library2.uri.toString();
       if (!_matchesSource(sourcePath, source)) return;
 
       reporter.atNode(node.identifier, entryCode);

--- a/lib/src/lints/avoid_using_api/avoid_using_api_utils.dart
+++ b/lib/src/lints/avoid_using_api/avoid_using_api_utils.dart
@@ -4,7 +4,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 extension SimpleIdentifierParentSourceExtension on SimpleIdentifier {
   /// Returns library of the node
   String? get sourceUrl {
-    final parentSource = staticElement?.librarySource;
+    final parentSource = element?.library2;
     final parentSourceName = parentSource?.uri.toString();
     return parentSourceName;
   }
@@ -14,7 +14,7 @@ extension SimpleIdentifierParentSourceExtension on SimpleIdentifier {
 extension NamedTypeParentSourceExtension on NamedType {
   /// Returns library of the node
   String? get sourceUrl {
-    final parentSource = element?.librarySource;
+    final parentSource = element2?.library2;
     final parentSourceName = parentSource?.uri.toString();
     return parentSourceName;
   }

--- a/lib/src/utils/typecast_utils.dart
+++ b/lib/src/utils/typecast_utils.dart
@@ -36,13 +36,13 @@ class TypeCast {
       return false;
     }
 
-    if (source.element == target.element) {
+    if (source.element3 == target.element3) {
       return _areGenericsWithSameTypeArgs;
     }
 
     if (source is InterfaceType) {
       return source.allSupertypes.any(
-        (e) => e.element == target.element,
+        (e) => e.element3 == target.element3,
       );
     }
 

--- a/lib/src/utils/types_utils.dart
+++ b/lib/src/utils/types_utils.dart
@@ -23,7 +23,7 @@
 // ignore_for_file: public_member_api_docs
 
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:collection/collection.dart';
@@ -31,8 +31,8 @@ import 'package:solid_lints/src/utils/named_type_utils.dart';
 
 extension Subtypes on DartType {
   Iterable<DartType> get supertypes {
-    final element = this.element;
-    return element is InterfaceElement ? element.allSupertypes : [];
+    final element = element3;
+    return element is InterfaceElement2 ? element.allSupertypes : [];
   }
 
   /// Formats the type string based on nullability and presence of generics.


### PR DESCRIPTION
- This PR replaces deprecated members from the `analyzer` package (e.g. `declaredElement` and `staticElement`) with their current equivalents.
- Changes are based on the official migration [guide](https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/doc/element_model_migration_guide.md)
- No functional changes were introduced
