### PR TITLE
Lint default constructor and named parameter (issue #126)

### DIFF
--- a/lib/src/lints/avoid_using_api/avoid_using_api_linter.dart
+++ b/lib/src/lints/avoid_using_api/avoid_using_api_linter.dart
@@ -20,7 +20,7 @@ class AvoidUsingApiLinter {
   });
 
   /// The identifier for the default constructor
-  static const String defaultConstructorIdentifier = '()';
+  static const String _defaultConstructorIdentifier = '()';
 
   /// Access to the resolver for this lint context
   final CustomLintResolver resolver;
@@ -194,7 +194,7 @@ class AvoidUsingApiLinter {
     String className,
     String source,
   ) {
-    if (identifier == defaultConstructorIdentifier) {
+    if (identifier == _defaultConstructorIdentifier) {
       _banDefaultConstructor(className, source, entryCode);
       return;
     }
@@ -348,7 +348,7 @@ class AvoidUsingApiLinter {
     context.registry.addInstanceCreationExpression((node) {
       String? expectedConstructorName;
 
-      if (identifier != defaultConstructorIdentifier) {
+      if (identifier != _defaultConstructorIdentifier) {
         expectedConstructorName = identifier;
       }
 

--- a/lib/src/lints/avoid_using_api/avoid_using_api_linter.dart
+++ b/lib/src/lints/avoid_using_api/avoid_using_api_linter.dart
@@ -332,7 +332,12 @@ class AvoidUsingApiLinter {
         return;
       }
 
-      final sourcePath = enclosingElement.library2?.uri.toString() ?? '';
+      final libSource = enclosingElement.library2;
+      if (libSource == null) {
+        return;
+      }
+
+      final sourcePath = libSource.uri.toString();
       if (!_matchesSource(sourcePath, source)) {
         return;
       }

--- a/lib/src/lints/avoid_using_api/avoid_using_api_linter.dart
+++ b/lib/src/lints/avoid_using_api/avoid_using_api_linter.dart
@@ -328,7 +328,7 @@ class AvoidUsingApiLinter {
         return;
       }
 
-      if (!_hasNamedParameter(node.argumentList, namedParameter)) {
+      if (!_containsNamedParameter(node.argumentList, namedParameter)) {
         return;
       }
 
@@ -346,10 +346,9 @@ class AvoidUsingApiLinter {
     });
 
     context.registry.addInstanceCreationExpression((node) {
-      final String? expectedConstructorName;
-      if (identifier == defaultConstructorIdentifier) {
-        expectedConstructorName = null;
-      } else {
+      String? expectedConstructorName;
+
+      if (identifier != defaultConstructorIdentifier) {
         expectedConstructorName = identifier;
       }
 
@@ -362,7 +361,7 @@ class AvoidUsingApiLinter {
         return;
       }
 
-      if (!_hasNamedParameter(node.argumentList, namedParameter)) {
+      if (!_containsNamedParameter(node.argumentList, namedParameter)) {
         return;
       }
 
@@ -376,7 +375,10 @@ class AvoidUsingApiLinter {
     });
   }
 
-  bool _hasNamedParameter(ArgumentList argumentList, String namedParameter) =>
+  bool _containsNamedParameter(
+    ArgumentList argumentList,
+    String namedParameter,
+  ) =>
       argumentList.arguments.any(
         (arg) =>
             arg is NamedExpression && arg.name.label.name == namedParameter,

--- a/lib/src/lints/avoid_using_api/avoid_using_api_rule.dart
+++ b/lib/src/lints/avoid_using_api/avoid_using_api_rule.dart
@@ -128,6 +128,19 @@ class AvoidUsingApiRule extends SolidLintRule<AvoidUsingApiParameters> {
           break;
         case AvoidUsingApiEntryParameters(
             :final identifier?,
+            :final namedParameter?,
+            :final className?,
+            :final source?
+          ):
+          linter.banUsageWithSpecificNamedParameter(
+            entryCode,
+            identifier,
+            namedParameter,
+            className,
+            source,
+          );
+        case AvoidUsingApiEntryParameters(
+            :final identifier?,
             :final className?,
             :final source?
           ):

--- a/lib/src/lints/avoid_using_api/models/avoid_using_api_entry_parameters.dart
+++ b/lib/src/lints/avoid_using_api/models/avoid_using_api_entry_parameters.dart
@@ -7,6 +7,7 @@ import 'package:solid_lints/src/utils/parameter_utils.dart';
 ///
 /// Parameters:
 /// * identifier: Variable/method name
+/// * named_parameter: Named parameter of the constructor/method
 /// * class_name: Name of the class containing the variable/method
 /// * source: Package (e.g., dart:async or package:example)
 /// * severity: The default severity of the lint for each entry.
@@ -35,6 +36,9 @@ class AvoidUsingApiEntryParameters {
   /// Variable/method name
   final String? identifier;
 
+  /// Named parameter of the constrcutor/method
+  final String? namedParameter;
+
   /// Name of the class containing the variable/method
   final String? className;
 
@@ -56,6 +60,7 @@ class AvoidUsingApiEntryParameters {
   /// Constructor for [AvoidUsingApiEntryParameters] model
   const AvoidUsingApiEntryParameters({
     this.identifier,
+    this.namedParameter,
     this.className,
     this.source,
     this.severity,
@@ -70,6 +75,7 @@ class AvoidUsingApiEntryParameters {
   ) =>
       AvoidUsingApiEntryParameters(
         identifier: json['identifier'] as String?,
+        namedParameter: json['named_parameter'] as String?,
         className: json['class_name'] as String?,
         source: json['source'] as String?,
         severity: decodeErrorSeverity(json['severity'] as String?),

--- a/lint_test/avoid_using_api/external_source/lib/external_source.dart
+++ b/lint_test/avoid_using_api/external_source/lib/external_source.dart
@@ -4,27 +4,35 @@
 class BannedCodeUsage {
   final String test4 = 'Hello World';
 
-  BannedCodeUsage();
+  BannedCodeUsage({this.parameter1, this.parameter2});
 
-  factory BannedCodeUsage.test3() {
-    return BannedCodeUsage();
+  String? parameter1;
+  String? parameter2;
+
+  factory BannedCodeUsage.test3({String? parameter1, String? parameter2}) {
+    return BannedCodeUsage(
+      parameter1: parameter1,
+      parameter2: parameter2,
+    );
   }
 
-  void test() {}
+  BannedCodeUsage.test5({String? parameter1, String? parameter2});
 
-  static String test2() {
+  void test({String? parameter1, String? parameter2}) {}
+
+  static String test2({String? parameter1, String? parameter2}) {
     return 'Hello World';
   }
 }
 
 const test2 = 'Hello World';
 
-void test() {}
+void test({String? parameter1}) {}
 
 int banned = 5;
 
 extension BannedExtension on int {
-  int banned() => this + 10;
+  int banned({String? parameter1, String? parameter2}) => this + 10;
 
   int get bannedGetter => 10;
 }

--- a/lint_test/avoid_using_api/external_source/lib/external_source.dart
+++ b/lint_test/avoid_using_api/external_source/lib/external_source.dart
@@ -4,35 +4,27 @@
 class BannedCodeUsage {
   final String test4 = 'Hello World';
 
-  BannedCodeUsage({this.parameter1, this.parameter2});
+  BannedCodeUsage();
 
-  String? parameter1;
-  String? parameter2;
-
-  factory BannedCodeUsage.test3({String? parameter1, String? parameter2}) {
-    return BannedCodeUsage(
-      parameter1: parameter1,
-      parameter2: parameter2,
-    );
+  factory BannedCodeUsage.test3() {
+    return BannedCodeUsage();
   }
 
-  BannedCodeUsage.test5({String? parameter1, String? parameter2});
+  void test() {}
 
-  void test({String? parameter1, String? parameter2}) {}
-
-  static String test2({String? parameter1, String? parameter2}) {
+  static String test2() {
     return 'Hello World';
   }
 }
 
 const test2 = 'Hello World';
 
-void test({String? parameter1}) {}
+void test() {}
 
 int banned = 5;
 
 extension BannedExtension on int {
-  int banned({String? parameter1, String? parameter2}) => this + 10;
+  int banned() => this + 10;
 
   int get bannedGetter => 10;
 }

--- a/lint_test/avoid_using_api/identifier_class_source_ban/analysis_options.yaml
+++ b/lint_test/avoid_using_api/identifier_class_source_ban/analysis_options.yaml
@@ -7,6 +7,10 @@ custom_lint:
     - avoid_using_api:
       severity: warning
       entries:
+        - identifier: ()
+          class_name: BannedCodeUsage
+          source: package:external_source
+          reason: "BannedCodeUsage() from package:external_source is not allowed"
         - identifier: test4
           class_name: BannedCodeUsage
           source: package:external_source

--- a/lint_test/avoid_using_api/identifier_class_source_ban/lib/identifier_class_source_ban_test.dart
+++ b/lint_test/avoid_using_api/identifier_class_source_ban/lib/identifier_class_source_ban_test.dart
@@ -5,6 +5,7 @@ import 'dart:collection';
 import 'package:external_source/external_source.dart';
 
 void testingBannedCodeLint() async {
+  // expect_lint: avoid_using_api
   final bannedCodeUsage = BannedCodeUsage();
   // expect_lint: avoid_using_api
   BannedCodeUsage.test2();

--- a/lint_test/avoid_using_api/named_parameter_ban/analysis_options.yaml
+++ b/lint_test/avoid_using_api/named_parameter_ban/analysis_options.yaml
@@ -8,32 +8,27 @@ custom_lint:
       severity: warning
       entries:
         - identifier: ()
-          named_parameter: parameter1
-          class_name: BannedCodeUsage
-          source: package:external_source
-          reason: "Use parameter2 instead"
-        - identifier: test3
-          named_parameter: parameter1
-          class_name: BannedCodeUsage
-          source: package:external_source
-          reason: "Use parameter2 instead"
-        - identifier: test5
-          named_parameter: parameter1
-          class_name: BannedCodeUsage
-          source: package:external_source
-          reason: "Use parameter2 instead"
-        - identifier: test2
-          named_parameter: parameter1
-          class_name: BannedCodeUsage
-          source: package:external_source
-          reason: "Use parameter2 instead"
-        - identifier: test
-          named_parameter: parameter1
-          class_name: BannedCodeUsage
-          source: package:external_source
-          reason: "Use parameter2 instead"
-        - identifier: banned
-          named_parameter: parameter1
-          class_name: BannedExtension
-          source: package:external_source
-          reason: "Use parameter2 instead"
+          named_parameter: badParameter
+          class_name: NamedParameterBan
+          source: package:named_parameter_ban
+          reason: "Use goodParameter instead"
+        - identifier: namedConstructor
+          named_parameter: badParameter
+          class_name: NamedParameterBan
+          source: package:named_parameter_ban
+          reason: "Use goodParameter instead"
+        - identifier: staticMethod
+          named_parameter: badParameter
+          class_name: NamedParameterBan
+          source: package:named_parameter_ban
+          reason: "Use goodParameter instead"
+        - identifier: method
+          named_parameter: badParameter
+          class_name: NamedParameterBan
+          source: package:named_parameter_ban
+          reason: "Use goodParameter instead"
+        - identifier: extensionMethod
+          named_parameter: badParameter
+          class_name: NamedParameterBanExtension
+          source: package:named_parameter_ban
+          reason: "Use goodParameter instead"

--- a/lint_test/avoid_using_api/named_parameter_ban/analysis_options.yaml
+++ b/lint_test/avoid_using_api/named_parameter_ban/analysis_options.yaml
@@ -1,0 +1,39 @@
+analyzer:
+  plugins:
+    - ../../custom_lint
+
+custom_lint:
+  rules:
+    - avoid_using_api:
+      severity: warning
+      entries:
+        - identifier: ()
+          named_parameter: parameter1
+          class_name: BannedCodeUsage
+          source: package:external_source
+          reason: "Use parameter2 instead"
+        - identifier: test3
+          named_parameter: parameter1
+          class_name: BannedCodeUsage
+          source: package:external_source
+          reason: "Use parameter2 instead"
+        - identifier: test5
+          named_parameter: parameter1
+          class_name: BannedCodeUsage
+          source: package:external_source
+          reason: "Use parameter2 instead"
+        - identifier: test2
+          named_parameter: parameter1
+          class_name: BannedCodeUsage
+          source: package:external_source
+          reason: "Use parameter2 instead"
+        - identifier: test
+          named_parameter: parameter1
+          class_name: BannedCodeUsage
+          source: package:external_source
+          reason: "Use parameter2 instead"
+        - identifier: banned
+          named_parameter: parameter1
+          class_name: BannedExtension
+          source: package:external_source
+          reason: "Use parameter2 instead"

--- a/lint_test/avoid_using_api/named_parameter_ban/lib/named_parameter_ban.dart
+++ b/lint_test/avoid_using_api/named_parameter_ban/lib/named_parameter_ban.dart
@@ -1,0 +1,16 @@
+class NamedParameterBan {
+  NamedParameterBan({this.badParameter, this.goodParameter});
+
+  String? badParameter;
+  String? goodParameter;
+
+  NamedParameterBan.namedConstructor(
+      {String? badParameter, String? goodParameter}) {}
+
+  void method({String? badParameter, String? goodParameter}) {}
+  static void staticMethod({String? badParameter, String? goodParameter}) {}
+}
+
+extension NamedParameterBanExtension on int {
+  String extensionMethod({String? badParameter, String? goodParameter}) => '';
+}

--- a/lint_test/avoid_using_api/named_parameter_ban/lib/named_parameter_ban_test.dart
+++ b/lint_test/avoid_using_api/named_parameter_ban/lib/named_parameter_ban_test.dart
@@ -1,28 +1,26 @@
-// ignore_for_file: unused_local_variable
-
-import 'package:external_source/external_source.dart';
+import 'package:named_parameter_ban/named_parameter_ban.dart';
 
 void testingBannedCodeLint() async {
   // expect_lint: avoid_using_api
-  final bannedCodeUsage = BannedCodeUsage(parameter1: '');
+  NamedParameterBan(badParameter: '');
+  NamedParameterBan(goodParameter: '');
 
   // expect_lint: avoid_using_api
-  final test3 = BannedCodeUsage.test3(parameter1: '');
+  NamedParameterBan.namedConstructor(badParameter: '');
+  NamedParameterBan.namedConstructor(goodParameter: '');
 
   // expect_lint: avoid_using_api
-  final test5 = BannedCodeUsage.test5(parameter1: '');
-
-  // expect_lint: avoid_using_api
-  BannedCodeUsage.test2(
-    parameter1: 'test',
+  NamedParameterBan.staticMethod(
+    badParameter: 'test',
   );
+  NamedParameterBan.staticMethod(goodParameter: '');
 
-  final obj = BannedCodeUsage();
+  final obj = NamedParameterBan();
   // expect_lint: avoid_using_api
-  obj.test(parameter1: '');
-
-  test(parameter1: '');
+  obj.method(badParameter: '');
+  obj.method(goodParameter: '');
 
   // expect_lint: avoid_using_api
-  2.banned(parameter1: '');
+  0.extensionMethod(badParameter: '');
+  0.extensionMethod(goodParameter: '');
 }

--- a/lint_test/avoid_using_api/named_parameter_ban/lib/named_parameter_ban_test.dart
+++ b/lint_test/avoid_using_api/named_parameter_ban/lib/named_parameter_ban_test.dart
@@ -1,0 +1,28 @@
+// ignore_for_file: unused_local_variable
+
+import 'package:external_source/external_source.dart';
+
+void testingBannedCodeLint() async {
+  // expect_lint: avoid_using_api
+  final bannedCodeUsage = BannedCodeUsage(parameter1: '');
+
+  // expect_lint: avoid_using_api
+  final test3 = BannedCodeUsage.test3(parameter1: '');
+
+  // expect_lint: avoid_using_api
+  final test5 = BannedCodeUsage.test5(parameter1: '');
+
+  // expect_lint: avoid_using_api
+  BannedCodeUsage.test2(
+    parameter1: 'test',
+  );
+
+  final obj = BannedCodeUsage();
+  // expect_lint: avoid_using_api
+  obj.test(parameter1: '');
+
+  test(parameter1: '');
+
+  // expect_lint: avoid_using_api
+  2.banned(parameter1: '');
+}

--- a/lint_test/avoid_using_api/named_parameter_ban/pubspec.yaml
+++ b/lint_test/avoid_using_api/named_parameter_ban/pubspec.yaml
@@ -1,4 +1,4 @@
-name: identifier_class_source_ban
+name: named_parameter_ban
 description: A sample command-line application.
 version: 1.0.0
 publish_to: none

--- a/lint_test/avoid_using_api/named_parameter_ban/pubspec.yaml
+++ b/lint_test/avoid_using_api/named_parameter_ban/pubspec.yaml
@@ -1,0 +1,17 @@
+name: identifier_class_source_ban
+description: A sample command-line application.
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: ^3.1.3
+
+dependencies:
+  external_source:
+    path: ../external_source
+
+dev_dependencies:
+  lints: ^3.0.0
+  test: ^1.21.0
+  solid_lints:
+    path: ../../../


### PR DESCRIPTION
Resolves #126 

Rule `avoid_using_api`:
- Lint only default constructor by using `()` identifier
- Lint usage of specific named parameter