### PR TITLE
Fix #192: Add analyzer.plugins setup to documentation and test configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Add an `analysis_options.yaml` file under the `test/` directory, and include the
 
 ```yaml
 include: package:solid_lints/analysis_options_test.yaml
+
+analyzer:
+  plugins:
+    - custom_lint
 ```
 
 Then you can see suggestions in your IDE or you can run checks manually:

--- a/lib/analysis_options_test.yaml
+++ b/lib/analysis_options_test.yaml
@@ -1,5 +1,9 @@
 include: package:solid_lints/analysis_options.yaml
 
+analyzer:
+  plugins:
+    - custom_lint
+
 custom_lint:
   rules:
 # Tests usually organized in one large main() function making this rule not applicable.

--- a/lib/src/lints/avoid_debug_print_in_release/avoid_debug_print_in_release_rule.dart
+++ b/lib/src/lints/avoid_debug_print_in_release/avoid_debug_print_in_release_rule.dart
@@ -59,7 +59,7 @@ your `debugPrint` call in a `!kReleaseMode` check.""",
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/avoid_final_with_getter/avoid_final_with_getter_rule.dart
+++ b/lib/src/lints/avoid_final_with_getter/avoid_final_with_getter_rule.dart
@@ -54,7 +54,7 @@ class AvoidFinalWithGetterRule extends SolidLintRule {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/avoid_global_state/avoid_global_state_rule.dart
+++ b/lib/src/lints/avoid_global_state/avoid_global_state_rule.dart
@@ -55,7 +55,7 @@ class AvoidGlobalStateRule extends SolidLintRule {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/avoid_late_keyword/avoid_late_keyword_rule.dart
+++ b/lib/src/lints/avoid_late_keyword/avoid_late_keyword_rule.dart
@@ -69,7 +69,7 @@ class AvoidLateKeywordRule extends SolidLintRule<AvoidLateKeywordParameters> {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/avoid_non_null_assertion/avoid_non_null_assertion_rule.dart
+++ b/lib/src/lints/avoid_non_null_assertion/avoid_non_null_assertion_rule.dart
@@ -58,7 +58,7 @@ class AvoidNonNullAssertionRule extends SolidLintRule {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/avoid_returning_widgets/avoid_returning_widgets_rule.dart
+++ b/lib/src/lints/avoid_returning_widgets/avoid_returning_widgets_rule.dart
@@ -75,7 +75,7 @@ class AvoidReturningWidgetsRule
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/avoid_unnecessary_setstate/avoid_unnecessary_set_state_rule.dart
+++ b/lib/src/lints/avoid_unnecessary_setstate/avoid_unnecessary_set_state_rule.dart
@@ -75,7 +75,7 @@ class AvoidUnnecessarySetStateRule extends SolidLintRule {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/avoid_unnecessary_type_assertions/avoid_unnecessary_type_assertions_rule.dart
+++ b/lib/src/lints/avoid_unnecessary_type_assertions/avoid_unnecessary_type_assertions_rule.dart
@@ -70,7 +70,7 @@ class AvoidUnnecessaryTypeAssertions extends SolidLintRule {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/avoid_unnecessary_type_casts/avoid_unnecessary_type_casts_rule.dart
+++ b/lib/src/lints/avoid_unnecessary_type_casts/avoid_unnecessary_type_casts_rule.dart
@@ -31,7 +31,7 @@ class AvoidUnnecessaryTypeCastsRule extends SolidLintRule {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     error_listener.ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/avoid_unrelated_type_assertions/avoid_unrelated_type_assertions_rule.dart
+++ b/lib/src/lints/avoid_unrelated_type_assertions/avoid_unrelated_type_assertions_rule.dart
@@ -29,7 +29,7 @@ class AvoidUnrelatedTypeAssertionsRule extends SolidLintRule {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/avoid_unused_parameters/avoid_unused_parameters_rule.dart
+++ b/lib/src/lints/avoid_unused_parameters/avoid_unused_parameters_rule.dart
@@ -88,7 +88,7 @@ class AvoidUnusedParametersRule extends SolidLintRule<AvoidUnusedParameters> {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/avoid_using_api/avoid_using_api_rule.dart
+++ b/lib/src/lints/avoid_using_api/avoid_using_api_rule.dart
@@ -87,7 +87,7 @@ class AvoidUsingApiRule extends SolidLintRule<AvoidUsingApiParameters> {
   }
 
   @override
-  Future<void> run(
+  Future<void> runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/cyclomatic_complexity/cyclomatic_complexity_rule.dart
+++ b/lib/src/lints/cyclomatic_complexity/cyclomatic_complexity_rule.dart
@@ -46,7 +46,7 @@ class CyclomaticComplexityRule
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/double_literal_format/double_literal_format_rule.dart
+++ b/lib/src/lints/double_literal_format/double_literal_format_rule.dart
@@ -72,7 +72,7 @@ class DoubleLiteralFormatRule extends SolidLintRule {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/function_lines_of_code/function_lines_of_code_rule.dart
+++ b/lib/src/lints/function_lines_of_code/function_lines_of_code_rule.dart
@@ -43,7 +43,7 @@ class FunctionLinesOfCodeRule
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/member_ordering/member_ordering_rule.dart
+++ b/lib/src/lints/member_ordering/member_ordering_rule.dart
@@ -108,7 +108,7 @@ class MemberOrderingRule extends SolidLintRule<MemberOrderingParameters> {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/named_parameters_ordering/named_parameters_ordering_rule.dart
+++ b/lib/src/lints/named_parameters_ordering/named_parameters_ordering_rule.dart
@@ -123,7 +123,7 @@ class NamedParametersOrderingRule
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/newline_before_return/newline_before_return_rule.dart
+++ b/lib/src/lints/newline_before_return/newline_before_return_rule.dart
@@ -92,7 +92,7 @@ class NewlineBeforeReturnRule extends SolidLintRule {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/no_empty_block/no_empty_block_rule.dart
+++ b/lib/src/lints/no_empty_block/no_empty_block_rule.dart
@@ -72,7 +72,7 @@ class NoEmptyBlockRule extends SolidLintRule<NoEmptyBlockParameters> {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/no_equal_then_else/no_equal_then_else_rule.dart
+++ b/lib/src/lints/no_equal_then_else/no_equal_then_else_rule.dart
@@ -61,7 +61,7 @@ class NoEqualThenElseRule extends SolidLintRule {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/no_magic_number/no_magic_number_rule.dart
+++ b/lib/src/lints/no_magic_number/no_magic_number_rule.dart
@@ -155,7 +155,7 @@ class NoMagicNumberRule extends SolidLintRule<NoMagicNumberParameters> {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/number_of_parameters/number_of_parameters_rule.dart
+++ b/lib/src/lints/number_of_parameters/number_of_parameters_rule.dart
@@ -59,7 +59,7 @@ class NumberOfParametersRule
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/prefer_conditional_expressions/prefer_conditional_expressions_rule.dart
+++ b/lib/src/lints/prefer_conditional_expressions/prefer_conditional_expressions_rule.dart
@@ -79,7 +79,7 @@ class PreferConditionalExpressionsRule
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/prefer_early_return/prefer_early_return_rule.dart
+++ b/lib/src/lints/prefer_early_return/prefer_early_return_rule.dart
@@ -51,7 +51,7 @@ class PreferEarlyReturnRule extends SolidLintRule {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/prefer_first/prefer_first_rule.dart
+++ b/lib/src/lints/prefer_first/prefer_first_rule.dart
@@ -47,7 +47,7 @@ class PreferFirstRule extends SolidLintRule {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/prefer_last/prefer_last_rule.dart
+++ b/lib/src/lints/prefer_last/prefer_last_rule.dart
@@ -47,7 +47,7 @@ class PreferLastRule extends SolidLintRule {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/prefer_match_file_name/prefer_match_file_name_rule.dart
+++ b/lib/src/lints/prefer_match_file_name/prefer_match_file_name_rule.dart
@@ -73,7 +73,7 @@ class PreferMatchFileNameRule
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/lints/proper_super_calls/proper_super_calls_rule.dart
+++ b/lib/src/lints/proper_super_calls/proper_super_calls_rule.dart
@@ -81,7 +81,7 @@ class ProperSuperCallsRule extends SolidLintRule {
   }
 
   @override
-  void run(
+  void runRule(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,

--- a/lib/src/models/solid_lint_rule.dart
+++ b/lib/src/models/solid_lint_rule.dart
@@ -1,5 +1,10 @@
+import 'dart:io';
+
+import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:solid_lints/src/models/rule_config.dart';
+import 'package:solid_lints/src/utils/path_utils.dart';
+import 'package:yaml/yaml.dart';
 
 /// A base class for emitting information about
 /// issues with user's `.dart` files.
@@ -11,6 +16,74 @@ abstract class SolidLintRule<T extends Object?> extends DartLintRule {
   /// defined custom parameters.
   final RuleConfig<T> config;
 
-  /// A flag which indicates whether this rule was enabled by the user.
+  /// A flag which indicates whether this rule was enabled by the user (globally).
   bool get enabled => config.enabled;
+
+  @override
+  void run(CustomLintResolver resolver,
+      ErrorReporter reporter,
+      CustomLintContext context,) {
+    if (!isEnabledForFile(resolver.path)) return;
+    runRule(resolver, reporter, context);
+  }
+
+  /// Override this method instead of run() in your rule implementations
+  void runRule(CustomLintResolver resolver,
+      ErrorReporter reporter,
+      CustomLintContext context,);
+
+  /// Determines if the rule should run for the given file.
+  bool isEnabledForFile(String filePath) {
+    if (!enabled) return false;
+    if (_isTestFile(filePath) && _isRuleDisabledInLocalConfig(filePath)) {
+      return false;
+    }
+    return true;
+  }
+
+  /// Checking if the file is a test file.
+  bool _isTestFile(String filePath) {
+    return filePath.contains('/test/') ||
+        filePath.contains(r'\test\') ||
+        filePath.endsWith('_test.dart');
+  }
+
+  /// Check if rule is disabled in local analysis_options.yaml config.
+  bool _isRuleDisabledInLocalConfig(String filePath) {
+    final configPath = findAnalysisOptionsForFile(filePath);
+    if (configPath == null) return false;
+
+    try {
+      final file = File(configPath);
+      if (!file.existsSync()) return false;
+
+      final content = file.readAsStringSync();
+      final yaml = loadYaml(content) as Map<String, dynamic>?;
+
+      if (yaml == null) return false;
+
+      final customLint = yaml['custom_lint'] as Map<String, dynamic>?;
+      if (customLint == null) return false;
+
+      final rules = customLint['rules'] as List?;
+      if (rules == null) return false;
+
+      /// Searching rule in rules list
+      for (final rule in rules) {
+        if (rule is String && rule == config.name) {
+          return false;
+        } else if (rule is Map) {
+          final key = rule.keys.first as String;
+          if (key == config.name) {
+            final value = rule.values.first;
+            return value == false;
+          }
+        }
+      }
+
+      return false;
+    } catch (e) {
+      return false;
+    }
+  }
 }


### PR DESCRIPTION
 - Added analyzer.plugins to test configuration example in README
- Updated lib/analysis_options_test.yaml to include analyzer.plugins to get correct configuration file
- Enabled cheching if file is test and getting correct directory
- Replace run() with runRule() in all rule implementations