### PR TITLE
fix: remove constructor from number_of_parameters rule

### DIFF
--- a/lib/src/lints/number_of_parameters/number_of_parameters_rule.dart
+++ b/lib/src/lints/number_of_parameters/number_of_parameters_rule.dart
@@ -6,8 +6,7 @@ import 'package:solid_lints/src/lints/number_of_parameters/visitors/number_of_pa
 import 'package:solid_lints/src/models/solid_lint_rule.dart';
 
 /// A number of parameters metric which checks whether we didn't exceed
-/// the maximum allowed number of parameters for a function, method or
-/// constructor.
+/// the maximum allowed number of parameters for a function or method.
 ///
 /// ### Example:
 ///
@@ -57,7 +56,7 @@ class NumberOfParametersRule
          name: lintName,
          description:
              "Checks whether we didn't exceed the maximum allowed number "
-             'of parameters for a function, method or constructor.',
+             'of parameters for a function or method.',
          parametersParser: NumberOfParametersParameters.fromJson,
        );
 
@@ -76,6 +75,5 @@ class NumberOfParametersRule
 
     registry.addFunctionDeclaration(this, visitor);
     registry.addMethodDeclaration(this, visitor);
-    registry.addConstructorDeclaration(this, visitor);
   }
 }

--- a/lib/src/lints/number_of_parameters/visitors/number_of_parameters_visitor.dart
+++ b/lib/src/lints/number_of_parameters/visitors/number_of_parameters_visitor.dart
@@ -4,8 +4,7 @@ import 'package:solid_lints/src/lints/number_of_parameters/models/number_of_para
 import 'package:solid_lints/src/lints/number_of_parameters/number_of_parameters_rule.dart';
 import 'package:solid_lints/src/utils/node_utils.dart';
 
-/// A visitor that checks the number of parameters for functions, methods, and
-/// constructors.
+/// A visitor that checks the number of parameters for functions and methods.
 class NumberOfParametersVisitor extends SimpleAstVisitor<void> {
   final NumberOfParametersRule _rule;
   final NumberOfParametersParameters _parameters;
@@ -36,11 +35,6 @@ class NumberOfParametersVisitor extends SimpleAstVisitor<void> {
   @override
   void visitMethodDeclaration(MethodDeclaration node) {
     if (isOverride(node.metadata)) return;
-    _check(node, node.parameters);
-  }
-
-  @override
-  void visitConstructorDeclaration(ConstructorDeclaration node) {
     _check(node, node.parameters);
   }
 }

--- a/test/src/lints/number_of_parameters/number_of_parameters_rule_test.dart
+++ b/test/src/lints/number_of_parameters/number_of_parameters_rule_test.dart
@@ -67,10 +67,10 @@ class UserDto {
 ''');
   }
 
-  Future<void> test_reports_on_constructors_exceeding_max_parameters() async {
-    await assertAutoDiagnostics('''
+  Future<void> test_does_not_report_on_constructors() async {
+    await assertNoDiagnostics(r'''
 class Test {
-  Test${expectLint(r'(int a, int b, int c)')};
+  Test(int a, int b, int c);
 }
 ''');
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the parameter-count lint to check only functions and methods.
  - Constructors with more parameters than the configured limit are no longer flagged.
- **Tests**
  - Updated lint coverage to confirm constructors produce no diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->