### PR TITLE
fix: resolve false positives in avoid_returning_widgets

### DIFF
--- a/lib/src/lints/avoid_returning_widgets/visitors/avoid_returning_widgets_visitor.dart
+++ b/lib/src/lints/avoid_returning_widgets/visitors/avoid_returning_widgets_visitor.dart
@@ -1,9 +1,9 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/dart/element/type.dart';
 import 'package:solid_lints/src/lints/avoid_returning_widgets/avoid_returning_widgets_rule.dart';
 import 'package:solid_lints/src/lints/avoid_returning_widgets/models/avoid_returning_widgets_parameters.dart';
+import 'package:solid_lints/src/utils/node_utils.dart';
 import 'package:solid_lints/src/utils/types_utils.dart';
 
 /// A visitor that reports on functions that return widgets.
@@ -40,20 +40,23 @@ class AvoidReturningWidgetsVisitor extends RecursiveAstVisitor<void> {
       return;
     }
 
+    if (node is MethodDeclaration &&
+        (node.isAbstract ||
+            node.body is EmptyFunctionBody ||
+            (node.isGetter && _isStateWidgetCastingGetter(node)))) {
+      return;
+    }
+
     final returnType = switch (node) {
-      Declaration(
-        declaredFragment: ExecutableFragment(
-          element: ExecutableElement(type: FunctionType(:final returnType)),
-        ),
-      ) =>
-        returnType,
-      MethodDeclaration(returnType: TypeAnnotation(:final type)) => type,
-      FunctionDeclaration(returnType: TypeAnnotation(:final type)) => type,
+      MethodDeclaration(:final declaredFragment?) =>
+        declaredFragment.element.returnType,
+      FunctionDeclaration(:final declaredFragment?) =>
+        declaredFragment.element.returnType,
       _ => null,
     };
     if (returnType == null) return;
 
-    final isWidgetReturned = hasWidgetType(returnType);
+    final isWidgetReturned = isWidgetType(returnType);
     if (!isWidgetReturned) return;
 
     final isIgnored = _parameters.exclude.shouldIgnore(node);
@@ -64,7 +67,27 @@ class AvoidReturningWidgetsVisitor extends RecursiveAstVisitor<void> {
     _rule.reportAtNode(node);
   }
 
+  bool _isStateWidgetCastingGetter(MethodDeclaration node) {
+    final enclosingElement = node.declaredFragment?.element.enclosingElement;
+    if (enclosingElement is! InterfaceElement ||
+        !isWidgetStateOrSubclass(enclosingElement.thisType)) {
+      return false;
+    }
+
+    final element = node.singleReturnExpression.unwrapTarget?.memberElement;
+    final enclosing = element?.enclosingElement;
+
+    return element is PropertyAccessorElement &&
+        enclosing is InterfaceElement &&
+        isWidgetStateOrSubclass(enclosing.thisType);
+  }
+
   bool _isOverridden(Declaration node) {
+    if (node is MethodDeclaration &&
+        node.metadata.any((m) => m.name.name == 'override')) {
+      return true;
+    }
+
     return switch (node) {
       Declaration(
         declaredFragment: Fragment(

--- a/lib/src/lints/avoid_returning_widgets/visitors/avoid_returning_widgets_visitor.dart
+++ b/lib/src/lints/avoid_returning_widgets/visitors/avoid_returning_widgets_visitor.dart
@@ -78,6 +78,7 @@ class AvoidReturningWidgetsVisitor extends RecursiveAstVisitor<void> {
     final enclosing = element?.enclosingElement;
 
     return element is PropertyAccessorElement &&
+        element.name == 'widget' &&
         enclosing is InterfaceElement &&
         isWidgetStateOrSubclass(enclosing.thisType);
   }

--- a/lib/src/lints/avoid_returning_widgets/visitors/avoid_returning_widgets_visitor.dart
+++ b/lib/src/lints/avoid_returning_widgets/visitors/avoid_returning_widgets_visitor.dart
@@ -74,7 +74,12 @@ class AvoidReturningWidgetsVisitor extends RecursiveAstVisitor<void> {
       return false;
     }
 
-    final element = node.singleReturnExpression.unwrapTarget?.memberElement;
+    final unwrapped = node.singleReturnExpression.unwrapTarget;
+    if (unwrapped?.targetExpression.isThisOrSuperOrNull != true) {
+      return false;
+    }
+
+    final element = unwrapped?.memberElement;
     final enclosing = element?.enclosingElement;
 
     return element is PropertyAccessorElement &&

--- a/lib/src/utils/node_utils.dart
+++ b/lib/src/utils/node_utils.dart
@@ -273,6 +273,7 @@ extension ExpressionExtension on Expression {
   /// Returns the member element referenced or operated on by this expression,
   /// or null if none.
   Element? get memberElement => switch (this) {
+    SimpleIdentifier(:final element) => element,
     MethodInvocation(:final methodName) => methodName.element,
     PropertyAccess(:final propertyName) => propertyName.element,
     AssignmentExpression(:final writeElement, :final readElement) ||
@@ -313,4 +314,18 @@ extension ExpressionNullableExtension on Expression? {
 
   /// Returns `true` if this expression is `this` or `super`.
   bool get isThisOrSuper => this is ThisExpression || this is SuperExpression;
+}
+
+/// Extension on [MethodDeclaration] to provide AST helper getters.
+extension MethodDeclarationExtension on MethodDeclaration {
+  /// Returns the single return expression of a method, or null if the
+  /// method body has multiple statements or no return expression.
+  Expression? get singleReturnExpression => switch (body) {
+    ExpressionFunctionBody(:final expression) => expression,
+    BlockFunctionBody(
+      block: Block(statements: [ReturnStatement(:final expression?)]),
+    ) =>
+      expression,
+    _ => null,
+  };
 }

--- a/lib/src/utils/types_utils.dart
+++ b/lib/src/utils/types_utils.dart
@@ -197,38 +197,42 @@ bool _checkSelfOrSupertypes(
     predicate(type) ||
     (type is InterfaceType && type.allSupertypes.any(predicate));
 
-bool _isWidget(DartType? type) =>
-    type is InterfaceType && type.element.name == 'Widget';
+bool _isWidget(DartType? type) => _isFlutterType(type, 'Widget');
 
 bool _isSubclassOfWidget(DartType? type) =>
     type is InterfaceType && type.allSupertypes.any(_isWidget);
 
-bool _isWidgetState(DartType? type) =>
-    type is InterfaceType && type.element.name == 'State';
+bool _isWidgetState(DartType? type) => _isFlutterType(type, 'State');
 
 bool _isSubclassOfWidgetState(DartType? type) =>
     type is InterfaceType && type.allSupertypes.any(_isWidgetState);
 
-bool _isListenable(DartType type) =>
-    type is InterfaceType && type.element.name == 'Listenable';
+bool _isListenable(DartType? type) => _isFlutterType(type, 'Listenable');
 
-bool _isRenderObject(DartType? type) =>
-    type is InterfaceType && type.element.name == 'RenderObject';
+bool _isRenderObject(DartType? type) => _isFlutterType(type, 'RenderObject');
 
 bool _isSubclassOfRenderObject(DartType? type) =>
     type is InterfaceType && type.allSupertypes.any(_isRenderObject);
 
 bool _isRenderObjectWidget(DartType? type) =>
-    type is InterfaceType && type.element.name == 'RenderObjectWidget';
+    _isFlutterType(type, 'RenderObjectWidget');
 
 bool _isSubclassOfRenderObjectWidget(DartType? type) =>
     type is InterfaceType && type.allSupertypes.any(_isRenderObjectWidget);
 
 bool _isRenderObjectElement(DartType? type) =>
-    type is InterfaceType && type.element.name == 'RenderObjectElement';
+    _isFlutterType(type, 'RenderObjectElement');
 
 bool _isSubclassOfRenderObjectElement(DartType? type) =>
     type is InterfaceType && type.allSupertypes.any(_isRenderObjectElement);
+
+bool _isFlutterType(DartType? type, String name) =>
+    type is InterfaceType &&
+    type.element.name == name &&
+    _isFlutterLibrary(type.element.library);
+
+bool _isFlutterLibrary(LibraryElement library) =>
+    library.uri.scheme == 'package' && library.uri.path.startsWith('flutter/');
 
 bool _isMultiProvider(DartType? type) =>
     type?.getDisplayString() == 'MultiProvider';

--- a/lib/src/utils/types_utils.dart
+++ b/lib/src/utils/types_utils.dart
@@ -26,7 +26,6 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:collection/collection.dart';
 import 'package:solid_lints/src/utils/named_type_utils.dart';
 
 extension Subtypes on DartType {
@@ -144,16 +143,9 @@ extension InterfaceElementExt on InterfaceElement {
   }
 }
 
-bool hasWidgetType(DartType type) =>
-    (isWidgetOrSubclass(type) ||
-        _isIterable(type) ||
-        _isList(type) ||
-        _isFuture(type)) &&
-    !(_isMultiProvider(type) ||
-        _isSubclassOfInheritedProvider(type) ||
-        _isIterableInheritedProvider(type) ||
-        _isListInheritedProvider(type) ||
-        _isFutureInheritedProvider(type));
+bool isWidgetType(DartType type) =>
+    isWidgetOrSubclass(type) &&
+    !(_isMultiProvider(type) || _isSubclassOfInheritedProvider(type));
 
 bool isIterable(DartType? type) =>
     _checkSelfOrSupertypes(type, (t) => t?.isDartCoreIterable ?? false);
@@ -205,48 +197,35 @@ bool _checkSelfOrSupertypes(
     predicate(type) ||
     (type is InterfaceType && type.allSupertypes.any(predicate));
 
-bool _isWidget(DartType? type) => type?.getDisplayString() == 'Widget';
+bool _isWidget(DartType? type) =>
+    type is InterfaceType && type.element.name == 'Widget';
 
 bool _isSubclassOfWidget(DartType? type) =>
     type is InterfaceType && type.allSupertypes.any(_isWidget);
 
-// ignore: deprecated_member_use
-bool _isWidgetState(DartType? type) => type?.element?.displayName == 'State';
+bool _isWidgetState(DartType? type) =>
+    type is InterfaceType && type.element.name == 'State';
 
 bool _isSubclassOfWidgetState(DartType? type) =>
     type is InterfaceType && type.allSupertypes.any(_isWidgetState);
 
-bool _isIterable(DartType type) =>
-    type.isDartCoreIterable &&
-    type is InterfaceType &&
-    isWidgetOrSubclass(type.typeArguments.firstOrNull);
-
-bool _isList(DartType type) =>
-    type.isDartCoreList &&
-    type is InterfaceType &&
-    isWidgetOrSubclass(type.typeArguments.firstOrNull);
-
-bool _isFuture(DartType type) =>
-    type.isDartAsyncFuture &&
-    type is InterfaceType &&
-    isWidgetOrSubclass(type.typeArguments.firstOrNull);
-
-bool _isListenable(DartType type) => type.getDisplayString() == 'Listenable';
+bool _isListenable(DartType type) =>
+    type is InterfaceType && type.element.name == 'Listenable';
 
 bool _isRenderObject(DartType? type) =>
-    type?.getDisplayString() == 'RenderObject';
+    type is InterfaceType && type.element.name == 'RenderObject';
 
 bool _isSubclassOfRenderObject(DartType? type) =>
     type is InterfaceType && type.allSupertypes.any(_isRenderObject);
 
 bool _isRenderObjectWidget(DartType? type) =>
-    type?.getDisplayString() == 'RenderObjectWidget';
+    type is InterfaceType && type.element.name == 'RenderObjectWidget';
 
 bool _isSubclassOfRenderObjectWidget(DartType? type) =>
     type is InterfaceType && type.allSupertypes.any(_isRenderObjectWidget);
 
 bool _isRenderObjectElement(DartType? type) =>
-    type?.getDisplayString() == 'RenderObjectElement';
+    type is InterfaceType && type.element.name == 'RenderObjectElement';
 
 bool _isSubclassOfRenderObjectElement(DartType? type) =>
     type is InterfaceType && type.allSupertypes.any(_isRenderObjectElement);
@@ -259,21 +238,6 @@ bool _isSubclassOfInheritedProvider(DartType? type) =>
 
 bool _isInheritedProvider(DartType? type) =>
     type != null && type.getDisplayString().startsWith('InheritedProvider<');
-
-bool _isIterableInheritedProvider(DartType type) =>
-    type.isDartCoreIterable &&
-    type is InterfaceType &&
-    _isSubclassOfInheritedProvider(type.typeArguments.firstOrNull);
-
-bool _isListInheritedProvider(DartType type) =>
-    type.isDartCoreList &&
-    type is InterfaceType &&
-    _isSubclassOfInheritedProvider(type.typeArguments.firstOrNull);
-
-bool _isFutureInheritedProvider(DartType type) =>
-    type.isDartAsyncFuture &&
-    type is InterfaceType &&
-    _isSubclassOfInheritedProvider(type.typeArguments.firstOrNull);
 
 bool isIterableOrSubclass(DartType? type) =>
     _checkSelfOrSupertypes(type, (t) => t?.isDartCoreIterable ?? false);

--- a/test/src/lints/avoid_returning_widgets/avoid_returning_widgets_rule_test.dart
+++ b/test/src/lints/avoid_returning_widgets/avoid_returning_widgets_rule_test.dart
@@ -357,4 +357,30 @@ class MyWidget extends StatelessWidget {
 }
 ''');
   }
+
+  Future<void> test_reports_on_non_widget_state_accessors() async {
+    await assertAutoDiagnostics('''
+$_importFlutterWidgets
+
+class OtherState extends State<StatefulWidget> {
+  ${expectLint('Widget get someWidget => const SizedBox();')}
+}
+
+class _TargetWidgetState extends State<StatefulWidget> {
+  late final OtherState otherState;
+
+  ${expectLint('Widget get customWidget => otherState.someWidget;')}
+}
+''');
+  }
+
+  Future<void> test_does_not_report_on_local_non_flutter_widget_class() async {
+    await assertNoDiagnostics('''
+class Widget {}
+
+class CustomService {
+  Widget createCustomWidget() => Widget();
+}
+''');
+  }
 }

--- a/test/src/lints/avoid_returning_widgets/avoid_returning_widgets_rule_test.dart
+++ b/test/src/lints/avoid_returning_widgets/avoid_returning_widgets_rule_test.dart
@@ -62,6 +62,16 @@ class BoxDecoration extends Widget {
   Widget build(BuildContext context) => throw 'unimplemented';
 }
 
+abstract class State<T extends StatefulWidget> {
+  T get widget => throw 'unimplemented';
+}
+
+class Color {}
+
+abstract interface class WidgetStateProperty<T> {}
+
+class WidgetStateColor extends Color implements WidgetStateProperty<Color> {}
+
 class DecoratedBox extends Widget {
   const DecoratedBox({required this.decoration});
 
@@ -264,6 +274,86 @@ class NotExcludeWidget extends StatelessWidget {
   }
 
   ${expectLint('Widget excludeWidgetMethod() => const SizedBox();')}
+}
+''');
+  }
+
+  Future<void> test_does_not_report_on_collections() async {
+    await assertNoDiagnostics('''
+$_importFlutterWidgets
+
+class MyWidget extends StatelessWidget {
+  const MyWidget({super.key});
+
+  List<Widget> buildList() => [const SizedBox()];
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox();
+  }
+}
+''');
+  }
+
+  Future<void> test_does_not_report_on_non_widget_types() async {
+    await assertNoDiagnostics('''
+$_importFlutterWidgets
+
+class MyWidget extends StatelessWidget {
+  const MyWidget({super.key});
+
+  WidgetStateColor getColor() => WidgetStateColor();
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox();
+  }
+}
+''');
+  }
+
+  Future<void> test_does_not_report_on_abstract_methods() async {
+    await assertNoDiagnostics('''
+$_importFlutterWidgets
+
+abstract class BaseStrategy {
+  Widget buildHeader(BuildContext context);
+}
+''');
+  }
+
+  Future<void> test_does_not_report_on_state_widget_getters() async {
+    await assertNoDiagnostics('''
+$_importFlutterWidgets
+
+class TargetWidget extends StatefulWidget {
+  const TargetWidget({super.key});
+}
+
+class _TargetWidgetState extends State<StatefulWidget> {
+  TargetWidget get widget => super.widget as TargetWidget;
+  TargetWidget get parenthesizedWidget => ((super.widget as TargetWidget));
+  TargetWidget get blockWidget {
+    return super.widget as TargetWidget;
+  }
+}
+''');
+  }
+
+  Future<void> test_does_not_report_on_inline_builder_callbacks() async {
+    await assertNoDiagnostics('''
+$_importFlutterWidgets
+
+void acceptBuilder(Widget Function(BuildContext) builder) {}
+
+class MyWidget extends StatelessWidget {
+  const MyWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    acceptBuilder((ctx) => const SizedBox());
+    return const SizedBox();
+  }
 }
 ''');
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the `avoid_returning_widgets` lint to avoid false positives for abstract or empty methods, widget collections, non-widget return types, and inline builder callbacks.
  - Correctly handles state widget accessors and overridden methods.
  - Improved widget type detection, including widget subclasses, while excluding supported provider-related cases.

- **Tests**
  - Added coverage for state classes, widget colors, widget state properties, and related lint scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->