### PR TITLE
refactor: update named parameters ordering priority 

### DIFF
--- a/lib/src/lints/named_parameters_ordering/models/parameter_type.dart
+++ b/lib/src/lints/named_parameters_ordering/models/parameter_type.dart
@@ -23,8 +23,8 @@ enum ParameterType {
   /// The default ordering of parameter types.
   static const defaultOrder = [
     ParameterType.requiredInherited,
-    ParameterType.inherited,
     ParameterType.required,
+    ParameterType.inherited,
     ParameterType.nullable,
     ParameterType.defaultValue,
   ];

--- a/test/src/lints/named_parameters_ordering/named_parameters_ordering_rule_test.dart
+++ b/test/src/lints/named_parameters_ordering/named_parameters_ordering_rule_test.dart
@@ -67,9 +67,9 @@ class User extends Base {
 
   User({
     required super.accountType,
-    super.userId,
     required this.name,
     required this.email,
+    super.userId,
     this.age,
     this.country,
     this.isActive = true,
@@ -113,8 +113,8 @@ class User extends Base {
   User({
     required super.accountType,
     this.age,
-    ${expectLint('super.userId')},
-    required this.name,
+    ${expectLint('required this.name')},
+    super.userId,
     this.isActive = true,
     ${expectLint('required this.email')},
   });


### PR DESCRIPTION
I'd like to swap required and super parameters in named_parameters_ordering to avoid a conflict with always_put_required_named_parameters_first

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved named-parameter ordering checks so required parameters are placed before inherited or superclass parameters.
  - Updated lint guidance for constructors using superclass parameters, producing more accurate warnings for incorrect ordering.

- **Tests**
  - Expanded coverage for required, local, and superclass parameter ordering scenarios to ensure consistent lint results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->