### PR TITLE
docs: add documentation for recommended third-party packages

### DIFF
--- a/doc/docusaurus/docs/3_other_notable_packages.md
+++ b/doc/docusaurus/docs/3_other_notable_packages.md
@@ -24,7 +24,7 @@ dart run undead@
 ```
 
 - **Links**: [pub.dev](https://pub.dev/packages/undead) ·
-  [GitHub](https://github.com/kevmoo/undead)
+  [GitHub](https://github.com/kevmoo/analytica.dart/tree/main/packages/undead)
 
 ---
 

--- a/doc/docusaurus/docs/3_other_notable_packages.md
+++ b/doc/docusaurus/docs/3_other_notable_packages.md
@@ -1,0 +1,46 @@
+---
+sidebar_label: Other notable packages
+sidebar_position: 3
+---
+
+# Other Notable Packages
+
+Recommended third-party tools that complement `solid_lints` in keeping Dart and
+Flutter codebases clean, robust, and maintainable.
+
+## [undead](https://pub.dev/packages/undead)
+
+[![pub package](https://img.shields.io/pub/v/undead.svg)](https://pub.dev/packages/undead)
+
+Deterministic reachability and dead/unused declaration analysis for Dart and
+Flutter packages.
+
+It performs whole-package AST analysis using `package:analyzer` to build a
+reachability graph from known entrypoints to all internal declarations,
+identifying unused top-level declarations, classes, functions, and variables.
+
+```bash
+dart run undead@
+```
+
+- **Links**: [pub.dev](https://pub.dev/packages/undead) ·
+  [GitHub](https://github.com/kevmoo/undead)
+
+---
+
+## [cognitive_complexity](https://pub.dev/packages/cognitive_complexity)
+
+[![pub package](https://img.shields.io/pub/v/cognitive_complexity.svg)](https://pub.dev/packages/cognitive_complexity)
+
+Algorithmic Cognitive Complexity calculation and Data-Flow analysis library and
+CLI tools for Dart and Flutter.
+
+It implements the Cognitive Complexity principles articulated by SonarSource,
+providing an objective way to find and fix overly complex logic and routines.
+
+```bash
+dart run cognitive_complexity@
+```
+
+- **Links**: [pub.dev](https://pub.dev/packages/cognitive_complexity) ·
+  [GitHub](https://github.com/kevmoo/analytica.dart/tree/main/packages/cognitive_complexity)

--- a/doc/docusaurus/docs/3_other_notable_packages.md
+++ b/doc/docusaurus/docs/3_other_notable_packages.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 
 # Other Notable Packages
 
-Recommended third-party tools that complement `solid_lints` in keeping Dart and
+Notable third-party tools that complement `solid_lints` in keeping Dart and
 Flutter codebases clean, robust, and maintainable.
 
 ## [undead](https://pub.dev/packages/undead)
@@ -18,10 +18,6 @@ Flutter packages.
 It performs whole-package AST analysis using `package:analyzer` to build a
 reachability graph from known entrypoints to all internal declarations,
 identifying unused top-level declarations, classes, functions, and variables.
-
-```bash
-dart run undead@
-```
 
 - **Links**: [pub.dev](https://pub.dev/packages/undead) ·
   [GitHub](https://github.com/kevmoo/analytica.dart/tree/main/packages/undead)
@@ -37,10 +33,6 @@ CLI tools for Dart and Flutter.
 
 It implements the Cognitive Complexity principles articulated by SonarSource,
 providing an objective way to find and fix overly complex logic and routines.
-
-```bash
-dart run cognitive_complexity@
-```
 
 - **Links**: [pub.dev](https://pub.dev/packages/cognitive_complexity) ·
   [GitHub](https://github.com/kevmoo/analytica.dart/tree/main/packages/cognitive_complexity)


### PR DESCRIPTION
- undead
- cognitive_complexity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the `undead` and `cognitive_complexity` Dart packages.
  * Included package descriptions, usage examples, badges, and links to pub.dev and GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->