### PR TITLE
fix: skip indexing and reporting for files located outside context root

### DIFF
--- a/lib/src/lints/avoid_duplicate_code/visitors/avoid_duplicate_code_visitor.dart
+++ b/lib/src/lints/avoid_duplicate_code/visitors/avoid_duplicate_code_visitor.dart
@@ -16,6 +16,7 @@ import 'package:solid_lints/src/lints/avoid_duplicate_code/reporters/avoid_dupli
 import 'package:solid_lints/src/lints/avoid_duplicate_code/reporters/duplicate_report_context.dart';
 import 'package:solid_lints/src/lints/avoid_duplicate_code/services/differing_literals_analyzer.dart';
 import 'package:solid_lints/src/lints/avoid_duplicate_code/services/global_hash_registry.dart';
+import 'package:solid_lints/src/lints/avoid_duplicate_code/utils/path_utils.dart';
 import 'package:solid_lints/src/lints/avoid_duplicate_code/utils/token_utils.dart';
 import 'package:solid_lints/src/lints/avoid_duplicate_code/visitors/ast_structural_hash_visitor.dart';
 import 'package:solid_lints/src/lints/avoid_duplicate_code/visitors/candidate_visitor.dart';
@@ -82,6 +83,11 @@ class AvoidDuplicateCodeVisitor extends RecursiveAstVisitor<void> {
   void visitCompilationUnit(CompilationUnit node) {
     if (_filePath.isEmpty) return;
     final filePath = _filePath;
+
+    if (_contextRoot != null &&
+        !PathUtils.isWithinOrEqual(_contextRoot.root.path, filePath)) {
+      return;
+    }
 
     final packageRoot =
         _contextRoot?.root.path ??

--- a/test/src/lints/avoid_duplicate_code/avoid_duplicate_code_rule_test.dart
+++ b/test/src/lints/avoid_duplicate_code/avoid_duplicate_code_rule_test.dart
@@ -871,6 +871,42 @@ void otherMethod() {
     expect(GlobalHashRegistry.instance.fileCount, 0);
   }
 
+  Future<void> test_does_not_index_or_report_file_outside_context_root() async {
+    final outsideFile = newFile('/other_package/lib/outside.dart', '''
+void outsideMethod() {
+  final x = 1;
+  if (x > 0) {
+    print(x);
+  }
+  print('done');
+}
+''');
+
+    final avoidRule = rule as AvoidDuplicateCodeRule;
+    final resolved = await resolveFile(testFile.path);
+    final contextRoot = resolved.session.analysisContext.contextRoot;
+
+    final parsed = parseString(content: outsideFile.readAsStringSync());
+
+    final visitor = AvoidDuplicateCodeVisitor(
+      avoidRule,
+      AvoidDuplicateCodeParameters(
+        minTokens: 10,
+        exclude: ExcludedIdentifiersListParameter(exclude: []),
+      ),
+      filePath: outsideFile.path,
+      modificationStamp: 1,
+      ignoreMatcher: avoidRule.ignoreMatcher,
+      contextRoot: contextRoot,
+      resourceProvider: resourceProvider,
+      analysisOptionsLoader: avoidRule.analysisOptionsLoader,
+    );
+
+    parsed.unit.accept(visitor);
+
+    expect(GlobalHashRegistry.instance.fileCount, 0);
+  }
+
   Future<void> _indexFile(
     File file, {
     AvoidDuplicateCodeParameters? parameters,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate-code analysis from scanning files outside the configured analysis context.
  * Avoided false duplicate-code reports from out-of-scope files.

* **Tests**
  * Added regression coverage to verify that files outside the analysis context are excluded from indexing and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->