### PR TITLE
fix: avoid returning widgets

### DIFF
--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -47,7 +47,11 @@ solid_lints:
       ignored_types:
         - AnimationController
     avoid_non_null_assertion: true
-    avoid_returning_widgets: true
+    avoid_returning_widgets:
+      ignored_types:
+        - MultiProvider
+        - InheritedProvider
+        - InheritedTheme
     avoid_similar_names: true
     avoid_unnecessary_return_variable: true
     avoid_unnecessary_setstate: true

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -47,11 +47,7 @@ solid_lints:
       ignored_types:
         - AnimationController
     avoid_non_null_assertion: true
-    avoid_returning_widgets:
-      ignored_types:
-        - MultiProvider
-        - InheritedProvider
-        - InheritedTheme
+    avoid_returning_widgets: true
     avoid_similar_names: true
     avoid_unnecessary_return_variable: true
     avoid_unnecessary_setstate: true

--- a/lib/src/common/parameters/ignored_types_list_parameter.dart
+++ b/lib/src/common/parameters/ignored_types_list_parameter.dart
@@ -44,6 +44,9 @@ class IgnoredTypesListParameter extends Equatable {
     return type.hasIgnoredType(ignoredTypes: ignoredTypes);
   }
 
+  /// Returns `true` if any of the target [types] should be ignored.
+  bool shouldIgnoreAny(Iterable<DartType?> types) => types.any(shouldIgnore);
+
   @override
   List<Object?> get props => [ignoredTypes];
 }

--- a/lib/src/common/parameters/ignored_types_list_parameter.dart
+++ b/lib/src/common/parameters/ignored_types_list_parameter.dart
@@ -1,0 +1,57 @@
+import 'package:analyzer/dart/element/type.dart';
+import 'package:collection/collection.dart';
+import 'package:solid_lints/src/utils/types_utils.dart';
+
+/// A parameter model representing ignored types for linting.
+/// It defines types that indicate when expressions, variables, or return values
+/// should be ignored during analysis.
+///
+/// @docType String | List<String> | Map<String, Object?>
+class IgnoredTypesListParameter {
+  /// The set of ignored type names.
+  final Set<String> ignoredTypes;
+
+  /// A common parameter key for analysis_options.yaml
+  static const String ignoredTypesKey = 'ignored_types';
+
+  /// Constructor for [IgnoredTypesListParameter] class.
+  const IgnoredTypesListParameter({
+    required this.ignoredTypes,
+  });
+
+  /// Empty [IgnoredTypesListParameter] model.
+  factory IgnoredTypesListParameter.empty() => const IgnoredTypesListParameter(
+    ignoredTypes: {},
+  );
+
+  /// Method for creating from json data.
+  factory IgnoredTypesListParameter.fromJson(Map<String, Object?> json) {
+    final raw = json[ignoredTypesKey];
+    final types = switch (raw) {
+      final Iterable<Object?> list => list.whereType<String>().toSet(),
+      final Map<Object?, Object?> map => map.keys.whereType<String>().toSet(),
+      final String str => {str},
+      _ => const <String>{},
+    };
+
+    return IgnoredTypesListParameter(ignoredTypes: types);
+  }
+
+  /// Returns whether the target type should be ignored during analysis.
+  bool shouldIgnore(DartType? type) {
+    if (type == null || ignoredTypes.isEmpty) return false;
+    return type.hasIgnoredType(ignoredTypes: ignoredTypes);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is IgnoredTypesListParameter &&
+          const SetEquality<String>().equals(
+            other.ignoredTypes,
+            ignoredTypes,
+          );
+
+  @override
+  int get hashCode => const SetEquality<String>().hash(ignoredTypes);
+}

--- a/lib/src/common/parameters/ignored_types_list_parameter.dart
+++ b/lib/src/common/parameters/ignored_types_list_parameter.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/element/type.dart';
-import 'package:collection/collection.dart';
+
+import 'package:equatable/equatable.dart';
 import 'package:solid_lints/src/utils/types_utils.dart';
 
 /// A parameter model representing ignored types for linting.
@@ -7,7 +8,7 @@ import 'package:solid_lints/src/utils/types_utils.dart';
 /// should be ignored during analysis.
 ///
 /// @docType String | List<String> | Map<String, Object?>
-class IgnoredTypesListParameter {
+class IgnoredTypesListParameter extends Equatable {
   /// The set of ignored type names.
   final Set<String> ignoredTypes;
 
@@ -44,14 +45,5 @@ class IgnoredTypesListParameter {
   }
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is IgnoredTypesListParameter &&
-          const SetEquality<String>().equals(
-            other.ignoredTypes,
-            ignoredTypes,
-          );
-
-  @override
-  int get hashCode => const SetEquality<String>().hash(ignoredTypes);
+  List<Object?> get props => [ignoredTypes];
 }

--- a/lib/src/lints/avoid_late_keyword/models/avoid_late_keyword_parameters.dart
+++ b/lib/src/lints/avoid_late_keyword/models/avoid_late_keyword_parameters.dart
@@ -1,3 +1,5 @@
+import 'package:solid_lints/src/common/parameters/ignored_types_list_parameter.dart';
+
 /// A data model class that represents the "avoid late keyword" input
 /// parameters.
 class AvoidLateKeywordParameters {
@@ -24,20 +26,18 @@ class AvoidLateKeywordParameters {
   /// late ColorTween tween; // OK
   /// late int colorValue; // LINT
   /// ```
-  final Iterable<String> ignoredTypes;
+  final IgnoredTypesListParameter ignoredTypes;
 
   /// Constructor for [AvoidLateKeywordParameters] model
   const AvoidLateKeywordParameters({
     this.allowInitialized = false,
-    this.ignoredTypes = const [],
+    this.ignoredTypes = const IgnoredTypesListParameter(ignoredTypes: {}),
   });
 
   /// Method for creating from json data
   factory AvoidLateKeywordParameters.fromJson(Map<String, Object?> json) =>
       AvoidLateKeywordParameters(
         allowInitialized: json['allow_initialized'] as bool? ?? false,
-        ignoredTypes: List<String>.from(
-          json['ignored_types'] as Iterable? ?? [],
-        ),
+        ignoredTypes: IgnoredTypesListParameter.fromJson(json),
       );
 }

--- a/lib/src/lints/avoid_late_keyword/visitors/avoid_late_keyword_visitor.dart
+++ b/lib/src/lints/avoid_late_keyword/visitors/avoid_late_keyword_visitor.dart
@@ -2,7 +2,6 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:solid_lints/src/lints/avoid_late_keyword/avoid_late_keyword_rule.dart';
 import 'package:solid_lints/src/lints/avoid_late_keyword/models/avoid_late_keyword_parameters.dart';
-import 'package:solid_lints/src/utils/types_utils.dart';
 
 /// Visitor for [AvoidLateKeywordRule].
 class AvoidLateKeywordVisitor extends SimpleAstVisitor<void> {
@@ -26,8 +25,7 @@ class AvoidLateKeywordVisitor extends SimpleAstVisitor<void> {
       !(_parameters.allowInitialized && node.initializer != null);
 
   bool _hasIgnoredType(VariableDeclaration node) =>
-      node.declaredFragment?.element.type.hasIgnoredType(
-        ignoredTypes: _parameters.ignoredTypes.toSet(),
-      ) ??
-      false;
+      _parameters.ignoredTypes.shouldIgnore(
+        node.declaredFragment?.element.type,
+      );
 }

--- a/lib/src/lints/avoid_non_null_assertion/models/avoid_non_null_assertion_parameters.dart
+++ b/lib/src/lints/avoid_non_null_assertion/models/avoid_non_null_assertion_parameters.dart
@@ -1,3 +1,5 @@
+import 'package:solid_lints/src/common/parameters/ignored_types_list_parameter.dart';
+
 /// A data model class that represents the "avoid non null assertion" input
 /// parameters.
 class AvoidNonNullAssertionParameters {
@@ -18,7 +20,7 @@ class AvoidNonNullAssertionParameters {
   /// Map<String, String> map;
   /// map['key']!; // OK
   /// ```
-  final Set<String> ignoredTypes;
+  final IgnoredTypesListParameter ignoredTypes;
 
   /// Constructor for [AvoidNonNullAssertionParameters] model
   const AvoidNonNullAssertionParameters({
@@ -27,23 +29,14 @@ class AvoidNonNullAssertionParameters {
 
   /// Empty [AvoidNonNullAssertionParameters] model, ignores nothing.
   factory AvoidNonNullAssertionParameters.empty() =>
-      const AvoidNonNullAssertionParameters(
-        ignoredTypes: {},
+      AvoidNonNullAssertionParameters(
+        ignoredTypes: IgnoredTypesListParameter.empty(),
       );
 
   /// Method for creating from json data
-  factory AvoidNonNullAssertionParameters.fromJson(Map<String, Object?> json) {
-    final raw = json['ignored_types'];
-    final excludeList = switch (raw) {
-      final Iterable<Object?> rawList => rawList.whereType<String>().toSet(),
-      final Map<Object?, Object?> rawMap =>
-        rawMap.keys.whereType<String>().toSet(),
-      final String rawString => {rawString},
-      _ => const <String>{},
-    };
-
-    return AvoidNonNullAssertionParameters(
-      ignoredTypes: excludeList,
-    );
-  }
+  factory AvoidNonNullAssertionParameters.fromJson(
+    Map<String, Object?> json,
+  ) => AvoidNonNullAssertionParameters(
+    ignoredTypes: IgnoredTypesListParameter.fromJson(json),
+  );
 }

--- a/lib/src/lints/avoid_non_null_assertion/visitors/avoid_non_null_assertion_visitor.dart
+++ b/lib/src/lints/avoid_non_null_assertion/visitors/avoid_non_null_assertion_visitor.dart
@@ -1,10 +1,8 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/dart/element/type.dart';
 import 'package:solid_lints/src/lints/avoid_non_null_assertion/avoid_non_null_assertion_rule.dart';
 import 'package:solid_lints/src/lints/avoid_non_null_assertion/models/avoid_non_null_assertion_parameters.dart';
-import 'package:solid_lints/src/utils/types_utils.dart';
 
 /// visitor for [AvoidNonNullAssertionRule]
 class AvoidNonNullAssertionVisitor extends SimpleAstVisitor<void> {
@@ -27,21 +25,11 @@ class AvoidNonNullAssertionVisitor extends SimpleAstVisitor<void> {
     if (operand is IndexExpression) {
       final type = operand.target?.staticType;
 
-      if (_hasIgnoredType(type)) {
+      if (_parameters.ignoredTypes.shouldIgnore(type)) {
         return;
       }
     }
 
     rule.reportAtNode(node);
-  }
-
-  bool _hasIgnoredType(DartType? type) {
-    if (type == null) {
-      return false;
-    }
-
-    return type.hasIgnoredType(
-      ignoredTypes: _parameters.ignoredTypes,
-    );
   }
 }

--- a/lib/src/lints/avoid_returning_widgets/avoid_returning_widgets_rule.dart
+++ b/lib/src/lints/avoid_returning_widgets/avoid_returning_widgets_rule.dart
@@ -21,6 +21,10 @@ import 'package:solid_lints/src/models/solid_lint_rule.dart';
 /// solid_lints:
 ///   diagnostics:
 ///     avoid_returning_widgets:
+///       ignored_types:
+///         - MultiProvider
+///         - InheritedProvider
+///         - InheritedTheme
 ///       exclude:
 ///         - class_name: MyWidget
 ///           method_name: buildCustomButton
@@ -57,6 +61,13 @@ import 'package:solid_lints/src/models/solid_lint_rule.dart';
 ///     return const SizedBox();
 ///   }
 /// }
+///
+/// // Allowed if MultiProvider / InheritedTheme is in ignored_types:
+/// MultiProvider buildProviders(Widget child) => MultiProvider(
+///   providers: [],
+///   child: child,
+/// );
+/// InputDecorationTheme get inputTheme => const InputDecorationTheme();
 /// ```
 class AvoidReturningWidgetsRule
     extends SolidLintRule<AvoidReturningWidgetsParameters> {

--- a/lib/src/lints/avoid_returning_widgets/models/avoid_returning_widgets_parameters.dart
+++ b/lib/src/lints/avoid_returning_widgets/models/avoid_returning_widgets_parameters.dart
@@ -1,5 +1,7 @@
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:solid_lints/src/common/parameters/excluded_identifiers_list_parameter.dart';
 import 'package:solid_lints/src/common/parameters/ignored_types_list_parameter.dart';
+import 'package:solid_lints/src/utils/node_utils.dart';
 
 /// A data model class that represents the "avoid returning widgets" input
 /// parameters.
@@ -45,4 +47,13 @@ class AvoidReturningWidgetsParameters {
     exclude: ExcludedIdentifiersListParameter.defaultFromJson(json),
     ignoredTypes: IgnoredTypesListParameter.fromJson(json),
   );
+
+  /// Returns `true` if the given [node] should be ignored by the lint rule.
+  bool shouldIgnore(Declaration node) {
+    return ignoredTypes.shouldIgnoreAny([
+          node.returnType,
+          node.singleReturnExpression?.staticType,
+        ]) ||
+        exclude.shouldIgnore(node);
+  }
 }

--- a/lib/src/lints/avoid_returning_widgets/models/avoid_returning_widgets_parameters.dart
+++ b/lib/src/lints/avoid_returning_widgets/models/avoid_returning_widgets_parameters.dart
@@ -1,4 +1,5 @@
 import 'package:solid_lints/src/common/parameters/excluded_identifiers_list_parameter.dart';
+import 'package:solid_lints/src/common/parameters/ignored_types_list_parameter.dart';
 
 /// A data model class that represents the "avoid returning widgets" input
 /// parameters.
@@ -6,22 +7,42 @@ class AvoidReturningWidgetsParameters {
   /// A list of methods that should be excluded from the lint.
   final ExcludedIdentifiersListParameter exclude;
 
+  /// Types that would be ignored by avoid-returning-widgets rule.
+  ///
+  /// Example:
+  ///
+  /// ```yaml
+  /// solid_lints:
+  ///   diagnostics:
+  ///     avoid_returning_widgets:
+  ///       ignored_types:
+  ///         - MultiProvider
+  ///         - InheritedTheme
+  /// ```
+  ///
+  /// ```dart
+  /// MultiProvider providers(Widget child) => MultiProvider(...); // OK
+  /// ```
+  final IgnoredTypesListParameter ignoredTypes;
+
   /// Constructor for [AvoidReturningWidgetsParameters] model
-  AvoidReturningWidgetsParameters({
+  const AvoidReturningWidgetsParameters({
     required this.exclude,
+    required this.ignoredTypes,
   });
 
   /// Empty [AvoidReturningWidgetsParameters] model, excludes nothing.
-  factory AvoidReturningWidgetsParameters.empty() {
-    return AvoidReturningWidgetsParameters(
-      exclude: ExcludedIdentifiersListParameter(exclude: []),
-    );
-  }
+  factory AvoidReturningWidgetsParameters.empty() =>
+      AvoidReturningWidgetsParameters(
+        exclude: ExcludedIdentifiersListParameter(exclude: []),
+        ignoredTypes: IgnoredTypesListParameter.empty(),
+      );
 
   /// Method for creating from json data
-  factory AvoidReturningWidgetsParameters.fromJson(Map<String, dynamic> json) {
-    return AvoidReturningWidgetsParameters(
-      exclude: ExcludedIdentifiersListParameter.defaultFromJson(json),
-    );
-  }
+  factory AvoidReturningWidgetsParameters.fromJson(
+    Map<String, Object?> json,
+  ) => AvoidReturningWidgetsParameters(
+    exclude: ExcludedIdentifiersListParameter.defaultFromJson(json),
+    ignoredTypes: IgnoredTypesListParameter.fromJson(json),
+  );
 }

--- a/lib/src/lints/avoid_returning_widgets/visitors/avoid_returning_widgets_visitor.dart
+++ b/lib/src/lints/avoid_returning_widgets/visitors/avoid_returning_widgets_visitor.dart
@@ -50,9 +50,8 @@ class AvoidReturningWidgetsVisitor extends RecursiveAstVisitor<void> {
         declaredFragment.element.returnType,
       _ => null,
     };
-    if (returnType == null) return;
 
-    if (!isWidgetType(returnType)) return;
+    if (!isWidgetOrSubclass(returnType)) return;
 
     // Only single-expression returns are checked against ignored types.
     // Functions with multiple returns/branches must explicitly specify the

--- a/lib/src/lints/avoid_returning_widgets/visitors/avoid_returning_widgets_visitor.dart
+++ b/lib/src/lints/avoid_returning_widgets/visitors/avoid_returning_widgets_visitor.dart
@@ -36,10 +36,6 @@ class AvoidReturningWidgetsVisitor extends RecursiveAstVisitor<void> {
   }
 
   void _visitDeclaration(Declaration node) {
-    if (node is! FunctionDeclaration && node is! MethodDeclaration) {
-      return;
-    }
-
     if (node is MethodDeclaration &&
         (!node.isComplete ||
             node.body is EmptyFunctionBody ||
@@ -56,10 +52,17 @@ class AvoidReturningWidgetsVisitor extends RecursiveAstVisitor<void> {
     };
     if (returnType == null) return;
 
-    final isWidgetReturned = isWidgetType(returnType);
-    if (!isWidgetReturned) return;
+    if (!isWidgetType(returnType)) return;
 
-    final isIgnored = _parameters.exclude.shouldIgnore(node);
+    // Only single-expression returns are checked against ignored types.
+    // Functions with multiple returns/branches must explicitly specify the
+    // ignored return type in their signature or be refactored into widgets.
+    final isIgnored =
+        _parameters.ignoredTypes.shouldIgnore(returnType) ||
+        _parameters.ignoredTypes.shouldIgnore(
+          node.singleReturnExpression?.staticType,
+        ) ||
+        _parameters.exclude.shouldIgnore(node);
     if (isIgnored) return;
 
     if (_isOverridden(node)) return;
@@ -89,8 +92,7 @@ class AvoidReturningWidgetsVisitor extends RecursiveAstVisitor<void> {
   }
 
   bool _isOverridden(Declaration node) {
-    if (node is MethodDeclaration &&
-        node.metadata.any((m) => m.name.name == 'override')) {
+    if (node is MethodDeclaration && isOverride(node.metadata)) {
       return true;
     }
 

--- a/lib/src/lints/avoid_returning_widgets/visitors/avoid_returning_widgets_visitor.dart
+++ b/lib/src/lints/avoid_returning_widgets/visitors/avoid_returning_widgets_visitor.dart
@@ -43,28 +43,11 @@ class AvoidReturningWidgetsVisitor extends RecursiveAstVisitor<void> {
       return;
     }
 
-    final returnType = switch (node) {
-      MethodDeclaration(:final declaredFragment?) =>
-        declaredFragment.element.returnType,
-      FunctionDeclaration(:final declaredFragment?) =>
-        declaredFragment.element.returnType,
-      _ => null,
-    };
-
-    if (!isWidgetOrSubclass(returnType)) return;
-
-    // Only single-expression returns are checked against ignored types.
-    // Functions with multiple returns/branches must explicitly specify the
-    // ignored return type in their signature or be refactored into widgets.
-    final isIgnored =
-        _parameters.ignoredTypes.shouldIgnore(returnType) ||
-        _parameters.ignoredTypes.shouldIgnore(
-          node.singleReturnExpression?.staticType,
-        ) ||
-        _parameters.exclude.shouldIgnore(node);
-    if (isIgnored) return;
-
-    if (_isOverridden(node)) return;
+    if (!isWidgetOrSubclass(node.returnType) ||
+        _parameters.shouldIgnore(node) ||
+        _isOverridden(node)) {
+      return;
+    }
 
     _rule.reportAtNode(node);
   }
@@ -91,11 +74,8 @@ class AvoidReturningWidgetsVisitor extends RecursiveAstVisitor<void> {
   }
 
   bool _isOverridden(Declaration node) {
-    if (node is MethodDeclaration && isOverride(node.metadata)) {
-      return true;
-    }
-
     return switch (node) {
+      MethodDeclaration(:final metadata) when isOverride(metadata) => true,
       Declaration(
         declaredFragment: Fragment(
           element: Element(

--- a/lib/src/utils/node_utils.dart
+++ b/lib/src/utils/node_utils.dart
@@ -327,16 +327,29 @@ extension ExpressionNullableExtension on Expression? {
   bool get isThisOrSuper => this is ThisExpression || this is SuperExpression;
 }
 
-/// Extension on [MethodDeclaration] to provide AST helper getters.
-extension MethodDeclarationExtension on MethodDeclaration {
-  /// Returns the single return expression of a method, or null if the
-  /// method body has multiple statements or no return expression.
-  Expression? get singleReturnExpression => switch (body) {
+/// Extension on [FunctionBody] to provide AST helper getters.
+extension FunctionBodyExtension on FunctionBody {
+  /// Returns the single return expression of a function body, or null if the
+  /// body has multiple statements or no return expression.
+  Expression? get singleReturnExpression => switch (this) {
     ExpressionFunctionBody(:final expression) => expression,
     BlockFunctionBody(
       block: Block(statements: [ReturnStatement(:final expression?)]),
     ) =>
       expression,
+    _ => null,
+  };
+}
+
+/// Extension on [Declaration] to provide AST helper getters.
+extension DeclarationExtension on Declaration {
+  /// Returns the single return expression of a declaration (method or
+  /// function), or null if the body has multiple statements or no return
+  /// expression.
+  Expression? get singleReturnExpression => switch (this) {
+    MethodDeclaration(:final body) => body.singleReturnExpression,
+    FunctionDeclaration(:final functionExpression) =>
+      functionExpression.body.singleReturnExpression,
     _ => null,
   };
 }

--- a/lib/src/utils/node_utils.dart
+++ b/lib/src/utils/node_utils.dart
@@ -352,4 +352,14 @@ extension DeclarationExtension on Declaration {
       functionExpression.body.singleReturnExpression,
     _ => null,
   };
+
+  /// Returns the declared return type of a declaration (method or
+  /// function), or null if none.
+  DartType? get returnType => switch (this) {
+    MethodDeclaration(:final declaredFragment?) =>
+      declaredFragment.element.returnType,
+    FunctionDeclaration(:final declaredFragment?) =>
+      declaredFragment.element.returnType,
+    _ => null,
+  };
 }

--- a/lib/src/utils/types_utils.dart
+++ b/lib/src/utils/types_utils.dart
@@ -144,8 +144,6 @@ extension InterfaceElementExt on InterfaceElement {
   }
 }
 
-bool isWidgetType(DartType type) => isWidgetOrSubclass(type);
-
 bool isIterable(DartType? type) =>
     _checkSelfOrSupertypes(type, (t) => t?.isDartCoreIterable ?? false);
 

--- a/lib/src/utils/types_utils.dart
+++ b/lib/src/utils/types_utils.dart
@@ -144,9 +144,7 @@ extension InterfaceElementExt on InterfaceElement {
   }
 }
 
-bool isWidgetType(DartType type) =>
-    isWidgetOrSubclass(type) &&
-    !(_isMultiProvider(type) || _isSubclassOfInheritedProvider(type));
+bool isWidgetType(DartType type) => isWidgetOrSubclass(type);
 
 bool isIterable(DartType? type) =>
     _checkSelfOrSupertypes(type, (t) => t?.isDartCoreIterable ?? false);
@@ -234,15 +232,6 @@ bool _isFlutterType(DartType? type, String name) =>
 
 bool _isFlutterLibrary(LibraryElement library) =>
     library.uri.scheme == 'package' && library.uri.path.startsWith('flutter/');
-
-bool _isMultiProvider(DartType? type) =>
-    type?.getDisplayString() == 'MultiProvider';
-
-bool _isSubclassOfInheritedProvider(DartType? type) =>
-    type is InterfaceType && type.allSupertypes.any(_isInheritedProvider);
-
-bool _isInheritedProvider(DartType? type) =>
-    type != null && type.getDisplayString().startsWith('InheritedProvider<');
 
 bool isIterableOrSubclass(DartType? type) =>
     _checkSelfOrSupertypes(type, (t) => t?.isDartCoreIterable ?? false);

--- a/test/src/common/parameters/parameters_parsing_test.dart
+++ b/test/src/common/parameters/parameters_parsing_test.dart
@@ -1,6 +1,7 @@
 import 'package:solid_lints/src/common/parameters/excluded_annotations_list_parameter.dart';
 import 'package:solid_lints/src/common/parameters/excluded_entities_list_parameter.dart';
 import 'package:solid_lints/src/common/parameters/excluded_identifiers_list_parameter.dart';
+import 'package:solid_lints/src/common/parameters/ignored_types_list_parameter.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -85,6 +86,35 @@ void main() {
     test('parses empty or invalid input', () {
       final param = ExcludedIdentifiersListParameter.defaultFromJson({});
       expect(param.exclude, isEmpty);
+    });
+  });
+
+  group('IgnoredTypesListParameter', () {
+    test('parses list of strings', () {
+      final param = IgnoredTypesListParameter.fromJson({
+        'ignored_types': ['Map', 'List'],
+      });
+      expect(param.ignoredTypes, containsAll(['Map', 'List']));
+    });
+
+    test('parses single string', () {
+      final param = IgnoredTypesListParameter.fromJson({
+        'ignored_types': 'Map',
+      });
+      expect(param.ignoredTypes, contains('Map'));
+      expect(param.ignoredTypes.length, 1);
+    });
+
+    test('parses map of keys', () {
+      final param = IgnoredTypesListParameter.fromJson({
+        'ignored_types': {'Map': true, 'List': false},
+      });
+      expect(param.ignoredTypes, containsAll(['Map', 'List']));
+    });
+
+    test('parses empty or invalid input', () {
+      final param = IgnoredTypesListParameter.fromJson({});
+      expect(param.ignoredTypes, isEmpty);
     });
   });
 }

--- a/test/src/lints/avoid_returning_widgets/avoid_returning_widgets_rule_test.dart
+++ b/test/src/lints/avoid_returning_widgets/avoid_returning_widgets_rule_test.dart
@@ -72,6 +72,42 @@ abstract interface class WidgetStateProperty<T> {}
 
 class WidgetStateColor extends Color implements WidgetStateProperty<Color> {}
 
+abstract class InheritedWidget extends Widget {
+  const InheritedWidget({super.key = ''});
+}
+
+abstract class InheritedTheme extends InheritedWidget {
+  const InheritedTheme({super.key = ''});
+}
+
+class InputDecorationTheme extends InheritedTheme {
+  const InputDecorationTheme({super.key = ''});
+
+  @override
+  Widget build(BuildContext context) => throw 'unimplemented';
+}
+
+class AppBarTheme extends InheritedTheme {
+  const AppBarTheme({super.key = ''});
+
+  @override
+  Widget build(BuildContext context) => throw 'unimplemented';
+}
+
+class MultiProvider extends InheritedWidget {
+  const MultiProvider({super.key = ''});
+
+  @override
+  Widget build(BuildContext context) => throw 'unimplemented';
+}
+
+class InheritedProvider<T> extends InheritedWidget {
+  const InheritedProvider({super.key = ''});
+
+  @override
+  Widget build(BuildContext context) => throw 'unimplemented';
+}
+
 class DecoratedBox extends Widget {
   const DecoratedBox({required this.decoration});
 
@@ -86,6 +122,10 @@ plugins:
   solid_lints:
     diagnostics:
       avoid_returning_widgets:
+        ignored_types:
+          - MultiProvider
+          - InheritedProvider
+          - InheritedTheme
         exclude:
           - class_name: ExcludeWidget 
             method_name: excludeWidgetMethod
@@ -380,6 +420,70 @@ class Widget {}
 
 class CustomService {
   Widget createCustomWidget() => Widget();
+}
+''');
+  }
+
+  Future<void> test_does_not_report_on_ignored_types_from_config() async {
+    await assertNoDiagnostics('''
+$_importFlutterWidgets
+
+class MyTheme {
+  InputDecorationTheme get inputDecorationTheme =>
+      const InputDecorationTheme();
+  AppBarTheme get appBarTheme => const AppBarTheme();
+  InheritedTheme get inheritedTheme => const InputDecorationTheme();
+  MultiProvider providers() => const MultiProvider();
+  InheritedProvider<String> provider() => const InheritedProvider<String>();
+}
+''');
+  }
+
+  Future<void> test_reports_when_not_in_ignored_types() async {
+    newAnalysisOptionsYamlFile(
+      testPackageRootPath,
+      analysisOptionsContent(rules: [rule.name]),
+    );
+
+    await assertAutoDiagnostics('''
+$_importFlutterWidgets
+
+class MyTheme {
+  ${expectLint('InputDecorationTheme get inputDecorationTheme => const InputDecorationTheme();')}
+  ${expectLint('MultiProvider providers() => const MultiProvider();')}
+}
+''');
+  }
+
+  Future<void>
+  test_does_not_report_on_function_returning_ignored_type_as_widget() async {
+    await assertNoDiagnostics('''
+$_importFlutterWidgets
+
+Widget providers(Widget child) => const MultiProvider();
+
+class MyClass {
+  Widget buildTheme() {
+    return const InputDecorationTheme();
+  }
+
+  Widget get themeGetter => const AppBarTheme();
+}
+''');
+  }
+
+  Future<void>
+  test_reports_on_function_returning_mixed_ignored_and_non_ignored() async {
+    await assertAutoDiagnostics('''
+$_importFlutterWidgets
+
+class MyClass {
+  ${expectLint('''Widget buildWidget(bool condition) {
+    if (condition) {
+      return const MultiProvider();
+    }
+    return const SizedBox();
+  }''')}
 }
 ''');
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ignored_types` configuration support for suppressing selected lint diagnostics.
  * Supports ignored types provided as a list, map, or single value.
  * Expanded “avoid returning widgets” handling for inherited and provider-based widget types.
* **Bug Fixes**
  * Improved detection of ignored types across declared and expression return types.
* **Documentation**
  * Added configuration examples for ignored widget types.
* **Tests**
  * Added coverage for parsing and ignored-type lint behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->